### PR TITLE
Redirecting Vera's doc PR that I missed

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,26 +2,29 @@ IBM z/OS CICS collection
 ========================
 
 The **IBM z/OS CICS collection**, also represented as **ibm\_zos\_cics**
-in this document, is part of the broader offering **Red Hat® Ansible
-Certified Content for IBM Z**. The IBM z/OS CICS collection supports management
-of CICS resources and definitions via the CMCI API.
+in this document, is part of the broader initiative to bring Ansible Automation to IBM Z® through the offering **Red Hat® Ansible Certified Content for IBM Z**. The IBM z/OS CICS collection supports management of CICS resources and definitions via the CMCI REST API provided by CICS.
 
 This CICS collection can work independently from other IBM z/OS modules on Ansible to perform tasks in CICS. You can, however, use it in conjunction with other IBM z/OS collections such as the 
 [IBM z/OS core collection](https://github.com/ansible-collections/ibm_zos_core) 
 to deliver a solution that will enable you to automate tasks on z/OS.
 
 
+Red Hat Ansible Certified Content for IBM Z
+===========================================
 
-Included Content
+**Red Hat Ansible Certified Content for IBM Z** provides the ability to connect IBM Z to clients\' wider enterprise automation strategy through the Ansible Automation Platform ecosystem. This enables development and operations automation on Z through a seamless, unified workflow orchestration with configuration management, provisioning, and application deployment in one easy-to-use platform.
+
+The **The IBM z/OS CICS collection** is following the **Red Hat Ansible Certified Content for IBM Z** method of distributing content. Collections will be developed in the open, and when content is ready for use it is released to [Ansible Galaxy](https://galaxy.ansible.com/search?keywords=zos_&order_by=-relevance&deprecated=false&type=collection&page=1) for community adoption. Once contributors review community usage, feedback, and are satisfied with the content published, the collection will then be released to [Ansible Automation Hub](https://www.ansible.com/products/automation-hub) as certified and IBM supported for Red Hat® Ansible Automation Platform subscribers. 
+
+For **guides** and **reference**, please visit [the documentation site](https://ansible-collections.github.io/ibm_zos_cics/).
+
+Features
 ================
 
 The IBM CICS collection includes
 [modules](https://github.com/ansible-collections/ibm_zos_cics/tree/master/plugins/modules/),
 [sample playbooks](https://github.com/ansible-collections/ibm_zos_cics/tree/master/playbooks/),
 and ansible-doc to automate tasks in CICS.
-
-For **guides** and **reference**, please visit [the documentation
-site](https://ansible-collections.github.io/ibm_zos_cics/).
 
 Contributing
 ============
@@ -32,20 +35,6 @@ We welcome bug reports and discussions about new function in the issue tracker, 
 
 For contribution guidelines, see [How to contribute](https://github.com/ansible-collections/ibm_zos_cics/tree/master/CONTRIBUTING.md).
 
-
-Red Hat Ansible Certified Content for IBM Z
-===========================================
-
-**Red Hat® Ansible Certified Content for IBM Z** provides the ability to
-connect IBM Z® to clients\' wider enterprise automation strategy through
-the Ansible Automation Platform ecosystem. This enables development and
-operations automation on Z through a seamless, unified workflow
-orchestration with configuration management, provisioning, and
-application deployment in one easy-to-use platform.
-
-**The IBM z/OS CICS collection**, as part of the broader offering
-**Red Hat® Ansible Certified Content for IBM Z**, is available on Galaxy as 
-community supported.
 
 Copyright
 =========

--- a/README.md
+++ b/README.md
@@ -6,9 +6,32 @@ in this document, is part of the broader offering **Red Hat® Ansible
 Certified Content for IBM Z**. The IBM z/OS CICS collection supports management
 of CICS resources and definitions via the CMCI API.
 
-The **IBM z/OS CICS collection** works closely with offerings such as the 
+This CICS collection can work independently from other IBM z/OS modules on Ansible to perform tasks in CICS. You can, however, use it in conjunction with other IBM z/OS collections such as the 
 [IBM z/OS core collection](https://github.com/ansible-collections/ibm_zos_core) 
 to deliver a solution that will enable you to automate tasks on z/OS.
+
+
+
+Included Content
+================
+
+The IBM CICS collection includes
+[modules](https://github.com/ansible-collections/ibm_zos_cics/tree/master/plugins/modules/),
+[sample playbooks](https://github.com/ansible-collections/ibm_zos_cics/tree/master/playbooks/),
+and ansible-doc to automate tasks in CICS.
+
+For **guides** and **reference**, please visit [the documentation
+site](https://ansible-collections.github.io/ibm_zos_cics/).
+
+Contributing
+============
+
+Thank you for contributing to this project.
+
+We welcome bug reports and discussions about new function in the issue tracker, and we also welcome proposed new features or bug fixes via pull requests.
+
+For contribution guidelines, see [How to contribute](https://github.com/ansible-collections/ibm_zos_cics/tree/master/CONTRIBUTING.md).
+
 
 Red Hat Ansible Certified Content for IBM Z
 ===========================================
@@ -23,17 +46,6 @@ application deployment in one easy-to-use platform.
 **The IBM z/OS CICS collection**, as part of the broader offering
 **Red Hat® Ansible Certified Content for IBM Z**, is available on Galaxy as 
 community supported.
-
-For **guides** and **reference**, please visit [the documentation
-site](https://ansible-collections.github.io/ibm_zos_cics/).
-
-Features
-========
-
-The IBM CICS collection includes
-[modules](https://github.com/ansible-collections/ibm_zos_cics/tree/master/plugins/modules/),
-[sample playbooks](https://github.com/ansible-collections/ibm_zos_cics/tree/master/playbooks/),
-and ansible-doc to automate tasks on CICS.
 
 Copyright
 =========

--- a/docs/ansible_content.rst
+++ b/docs/ansible_content.rst
@@ -8,7 +8,8 @@ IBM z/OS CICS Collection
 The **IBM z/OS CICS collection**, also represented as **ibm\_zos\_cics**
 in this document, provides tasks to define, install, and perform actions on CICS definitions and resources such as creating a PROGRAM definition, installing and updating it, and deleting the definition.
 
-The **IBM z/OS CICS collection** can work independently from other IBM z/OS modules on Ansible to perform tasks in CICS. You can, however, to use it in conjunction with the `IBM z/OS core collection`_ to achieve more automation on z/OS. If you do that, always refer to their documentation for extra configuration needed.
+The **IBM z/OS CICS collection** can work independently from other IBM z/OS modules on Ansible to perform tasks in CICS. You can, however, to use it in conjunction with the `IBM z/OS core collection`_ to deliver a solution that will enable you to automate tasks on z/OS. If you choose to do that, you can refer to their documentation for the extra configuration needed.
+
 
 .. _IBM z/OS core collection:
    https://github.com/ansible-collections/ibm_zos_core

--- a/docs/ansible_content.rst
+++ b/docs/ansible_content.rst
@@ -1,0 +1,21 @@
+.. ...........................................................................
+.. © Copyright IBM Corporation 2020                                          .
+.. ...........................................................................
+
+IBM z/OS CICS Collection
+========================
+
+The **IBM z/OS CICS collection**, also represented as **ibm\_zos\_cics**
+in this document, provides tasks to define, install, and perform actions on CICS definitions and resources such as creating a PROGRAM definition, installing and updating it, and deleting the definition.
+
+The **IBM z/OS CICS collection** can work independently from other IBM z/OS modules on Ansible to perform tasks in CICS. You can, however, to use it in conjunction with the `IBM z/OS core collection`_ to achieve more automation on z/OS. If you do that, always refer to their documentation for extra configuration needed.
+
+.. _IBM z/OS core collection:
+   https://github.com/ansible-collections/ibm_zos_core
+
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Reference
+
+   source/modules

--- a/docs/source/community_guides.rst
+++ b/docs/source/community_guides.rst
@@ -6,14 +6,15 @@
 Contributing
 ============
 
-We are not currently accepting community contributions. However, we encourage
-you to open `git issues`_ for bugs, comments or feature requests.
+Thank you for contributing to this project.
 
-Review this content periodically to learn when and how to make contributions in
-the future.
+We welcome bug reports and discussions about new function in the issue tracker, and we also welcome proposed new features or bug fixes via pull requests.
 
-.. _git issues:
-   https://github.com/ansible-collections/ibm_zos_cics/issues
+For contribution guidelines, see `How to contribute`_.
+
+.. _How to contribute:
+   https://github.com/ansible-collections/ibm_zos_cics/tree/master/CONTRIBUTING.md
+
 
 
 

--- a/docs/source/community_guides.rst
+++ b/docs/source/community_guides.rst
@@ -15,12 +15,5 @@ the future.
 .. _git issues:
    https://github.com/ansible-collections/ibm_zos_cics/issues
 
-Helpful Links
-=============
-
-* Getting Started `Ansible guide`_.
-
-.. _Ansible guide:
-   https://docs.ansible.com/ansible/latest/user_guide/intro_getting_started.html
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,7 +10,7 @@ Collections are a distribution format for prepackaged Ansible content including 
 The **IBM z/OS CICS collection**, also represented as **ibm\_zos\_cics**
 in this document, provides tasks to define, install, and perform actions on CICS definitions and resources such as creating a PROGRAM definition, installing and updating it, and deleting the definition.
 
-This CICS collection can work independently from other IBM z/OS modules on Ansible to perform tasks in CICS. You can, however, to use it in conjunction with the `IBM z/OS core collection`_ to achieve more automation on z/OS. If you do that, always refer to their documentation for extra configuration needed.
+This CICS collection can work independently from other IBM z/OS modules on Ansible to perform tasks in CICS. You can, however, to use it in conjunction with the `IBM z/OS core collection`_ to deliver a solution that will enable you to automate tasks on z/OS. If you choose to do that, you can refer to their documentation for the extra configuration needed.
 
 .. _IBM z/OS core collection:
    https://github.com/ansible-collections/ibm_zos_core

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,11 +5,12 @@
 
 IBM z/OS CICS collection
 ========================
+Collections are a distribution format for prepackaged Ansible content including playbooks, modules, and so on that enable you to quickly set up your automation project.
 
 The **IBM z/OS CICS collection**, also represented as **ibm\_zos\_cics**
-in this document, provides tasks to define, install, and perform actions on CICS resources such as creating a PROGRAM definition, installing and updating it, and deleting the definition.
+in this document, provides tasks to define, install, and perform actions on CICS definitions and resources such as creating a PROGRAM definition, installing and updating it, and deleting the definition.
 
-The **IBM z/OS CICS collection** can work independently from other IBM z/OS modules on Ansible to perform tasks in CICS. You can, however, to use it in conjunction with the `IBM z/OS core collection`_ to achieve more automation on z/OS. If you do that, always refer to their documentation for extra configuration needed.
+This CICS collection can work independently from other IBM z/OS modules on Ansible to perform tasks in CICS. You can, however, to use it in conjunction with the `IBM z/OS core collection`_ to achieve more automation on z/OS. If you do that, always refer to their documentation for extra configuration needed.
 
 .. _IBM z/OS core collection:
    https://github.com/ansible-collections/ibm_zos_core
@@ -17,19 +18,26 @@ The **IBM z/OS CICS collection** can work independently from other IBM z/OS modu
 Included content
 ================
 
-The IBM z/OS CICS collection includes modules, sample playbooks, and ansible-doc to automate tasks against CICS resources and definitions.
+The IBM z/OS CICS collection includes `modules`_, `sample playbooks`_, and ansible-doc to automate tasks against CICS resources and definitions.
 
-.. toctree::
-   :maxdepth: 3
-
-   modules
-   playbooks
 
 
 .. _modules:
     https://github.com/ansible-collections/ibm_zos_cics/tree/master/plugins/modules/
 .. _sample playbooks:
     https://github.com/ansible-collections/ibm_zos_cics/tree/master/playbooks/
+
+Contributing
+============
+
+Thank you for contributing to this project.
+
+We welcome bug reports and discussions about new function in the issue tracker, and we also welcome proposed new features or bug fixes via pull requests.
+
+For contribution guidelines, see `How to contribute`_.
+
+.. _How to contribute:
+   https://github.com/ansible-collections/ibm_zos_cics/tree/master/CONTRIBUTING.md
 
 
 Red Hat Ansible Certified Content for IBM Z
@@ -63,21 +71,23 @@ This collection is licensed under `Apache License, Version 2.0`_.
 
 .. toctree::
    :maxdepth: 1
+   :caption: Requirements
+
+   requirements
+
+.. toctree::
+   :maxdepth: 1
    :caption: Getting Started
 
    installation
 
 .. toctree::
-   :maxdepth: 1
-   :caption: Community guides
+   :maxdepth: 3
+   :caption: Reference
 
-   community_guides
+   modules
+   playbooks
 
-.. toctree::
-   :maxdepth: 1
-   :caption: Requirements
-
-   requirements
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,12 +19,7 @@ This CICS collection can work independently from other IBM z/OS modules on Ansib
 Red Hat Ansible Certified Content for IBM Z
 ===========================================
 
-**Red Hat® Ansible Certified Content for IBM Z** provides the ability to
-connect IBM Z® to clients' wider enterprise automation strategy through the
-Ansible Automation Platform ecosystem. This enables development and operations
-automation on Z through a seamless, unified workflow orchestration with
-configuration management, provisioning, and application deployment in one
-easy-to-use platform.
+**Red Hat® Ansible Certified Content for IBM Z** provides the ability to connect IBM Z® to clients' wider enterprise automation strategy through the Ansible Automation Platform ecosystem. This enables development and operations automation on Z through a seamless, unified workflow orchestration with configuration management, provisioning, and application deployment in one easy-to-use platform.
 
 The **The IBM z/OS CICS collection** is following the **Red Hat Ansible Certified Content for IBM Z** method of distributing content. Collections will be developed in the open, and when content is ready for use it is released to `Ansible Galaxy`_ for community adoption. Once contributors review community usage, feedback, and are satisfied with the content published, the collection will then be released to `Ansible Automation Hub`_ as certified and IBM supported for Red Hat® Ansible Automation Platform subscribers.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,7 +15,26 @@ This CICS collection can work independently from other IBM z/OS modules on Ansib
 .. _IBM z/OS core collection:
    https://github.com/ansible-collections/ibm_zos_core
 
-Included content
+
+Red Hat Ansible Certified Content for IBM Z
+===========================================
+
+**Red Hat® Ansible Certified Content for IBM Z** provides the ability to
+connect IBM Z® to clients' wider enterprise automation strategy through the
+Ansible Automation Platform ecosystem. This enables development and operations
+automation on Z through a seamless, unified workflow orchestration with
+configuration management, provisioning, and application deployment in one
+easy-to-use platform.
+
+The **The IBM z/OS CICS collection** is following the **Red Hat Ansible Certified Content for IBM Z** method of distributing content. Collections will be developed in the open, and when content is ready for use it is released to `Ansible Galaxy`_ for community adoption. Once contributors review community usage, feedback, and are satisfied with the content published, the collection will then be released to `Ansible Automation Hub`_ as certified and IBM supported for Red Hat® Ansible Automation Platform subscribers.
+
+.. _Ansible Galaxy:
+   https://galaxy.ansible.com/search?keywords=zos_&order_by=-relevance&deprecated=false&type=collection&page=1
+
+.. _Ansible Automation Hub:
+   https://www.ansible.com/products/automation-hub
+
+Features
 ================
 
 The IBM z/OS CICS collection includes `modules`_, `sample playbooks`_, and ansible-doc to automate tasks against CICS resources and definitions.
@@ -40,21 +59,6 @@ For contribution guidelines, see `How to contribute`_.
    https://github.com/ansible-collections/ibm_zos_cics/tree/master/CONTRIBUTING.md
 
 
-Red Hat Ansible Certified Content for IBM Z
-===========================================
-
-**Red Hat® Ansible Certified Content for IBM Z** provides the ability to
-connect IBM Z® to clients' wider enterprise automation strategy through the
-Ansible Automation Platform ecosystem. This enables development and operations
-automation on Z through a seamless, unified workflow orchestration with
-configuration management, provisioning, and application deployment in one
-easy-to-use platform.
-
-**The IBM z/OS CICS collection**, as part of the broader offering
-**Red Hat® Ansible Certified Content for IBM Z**, is available on Galaxy as 
-community supported.
-
-
 
 Copyright
 =========
@@ -69,28 +73,31 @@ This collection is licensed under `Apache License, Version 2.0`_.
 .. _Apache License, Version 2.0:
     https://opensource.org/licenses/Apache-2.0
 
-.. toctree::
-   :maxdepth: 1
-   :caption: Requirements
-
-   requirements
 
 .. toctree::
    :maxdepth: 1
    :caption: Getting Started
 
+   requirements
    installation
+   playbooks
 
 .. toctree::
-   :maxdepth: 3
-   :caption: Reference
+   :maxdepth: 1
+   :caption: Ansible Content
 
    modules
-   playbooks
 
 
 .. toctree::
    :maxdepth: 1
-   :caption: Appendices
+   :caption: Release Notes
 
    release_notes
+
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Reference
+
+   community_guides

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -5,33 +5,36 @@
 
 Installation
 ============
-You can install the **IBM z/OS CICS collection** from Ansible Galaxy, a custom Galaxy server, or a local build, using the `ansible-galaxy`_ command.
+Always check that your control node has fulfilled the :doc:`requirements` before installing the **IBM z/OS CICS collection**.
+
+Then, follow the guidance to install the collection from Ansible Galaxy or a custom Galaxy server. More ways to install an Ansible collection are documented at `installing collections`_.
 
 .. note:: Python module dependencies are not installed with the collection. To use the collection, you must install Python dependencies where the task will be running, in our case, the control node. See `Installing Python dependencies`_.
 
 Installing Python dependencies
 -------------------------------
-You can use the supplied ``requirements`` file to install the dependencies:
+You can use the supplied ``prod-requirements`` file to install the dependencies:
 
 .. code-block:: sh
 
-   pip install requirements.txt
+   pip install prod-requirements.txt
 
 
-.. this is a placeholder, no requirements file created yet.
+Alternatively, you can install the dependencies manually:
 
-If you want to install the dependencies manually, here are the requirements of the control node:
+* `requests`_ package
+* `xmltodict`_ 0.12.0
 
-* `Ansible version`_: 2.9 or later
+.. _requests:
+   https://pypi.org/project/requests/
 
-.. _Ansible version:
-   https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html
-
+.. _xmltodict:
+   https://pypi.org/project/xmltodict/
 
 
 Installing from Ansible Galaxy
 ------------------------------
-Install the CICS collection from CLI:
+This is the quickest way to install the CICS collection. From your CLI, enter:
 
 .. code-block:: sh
 
@@ -74,54 +77,6 @@ To install with customization, such as specifying another installation path or u
 
 .. _installing collections:
    https://docs.ansible.com/ansible/latest/user_guide/collections_using.html#installing-collections-with-ansible-galaxy
-
-Installing from a local build
-------------------------------
-
-You can clone the collection's Git repository, build the cloned collection into an archive file, and then install the collection using the archive file.
-
-.. comment: need to add the link to GitHub repository
-
-To build a collection from the Git repository:
-
-   #. Clone the repository.
-
-   #. Build the collection by running the ``ansible-galaxy collection build`` command, from inside the collection:
-
-      .. code-block:: sh
-
-         cd ibm_zos_cics
-         ansible-galaxy collection build
-
-      Example output:
-
-      .. code-block:: sh
-
-         $ ansible-galaxy collection build
-         Created collection for ibm.ibm_zos_cics at /Users/user/git/ibm/zos-ansible/ibm_zos_cics/ibm-ibm_zos_cics-1.0.0.tar.gz
-
-      .. note::
-         * Collection archive names will change depending on the release version. They adhere to this convention ``<namespace>-<collection>-<version>.tar.gz``, for example, ``ibm-ibm_zos_cics-1.0.0.tar.gz``.
-         * If you build the collection with Ansible version 2.9 or earlier, you will see the following warning that you can ignore: [WARNING]: Found unknown keys in collection galaxy.yml at '/Users/user/git/ibm/zos-ansible/ibm_zos_cics/galaxy.yml': build_ignore
-
-
-   #. Install the locally built collection:
-
-      .. code-block:: sh
-
-         $ ansible-galaxy collection install ibm-ibm_zos_cics-1.0.0.tar.gz
-
-      The output will look like this:
-
-      .. code-block:: sh
-
-         Process install dependency map
-         Starting collection install process
-         Installing 'ibm.ibm_zos_cics:1.0.0' to '/Users/user/.ansible/collections/ansible_collections/ibm/ibm_zos_cics'
-
-      To install with customization, such as specifying another installation path or using a playbook, see `installing collections`_.
-
-
 
 
 Installing from a custom Galaxy server

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -6,21 +6,12 @@
 Modules
 =======
 
-The IBM z/OS CICS collection contains modules that can be used in a playbook to
-automate tasks on z/OS. Ansible executes each module on the target node and
-returns the result back to the controller. While different modules perform
-different tasks, their interfaces and responses follow similar patterns.
+Modules can be used in a playbook to automate tasks. Ansible executes each module on the target node and returns the result back to the controller.
 
-Module reference
-----------------
-
-Reference material for each module contains documentation on the accepted
-parameters and their expected values.
-
+The IBM z/OS CICS collection contains these modules. For each module, the accepted parameters, return values, and examples are provided in the documentation.
 
 .. toctree::
    :maxdepth: 1
-   :caption: Contents:
    :glob:
 
    modules/*

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,24 +3,63 @@
 .. Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)  .
 .. ...............................................................................
 
+========
 Releases
 ========
 
 Version 1.0.0
+=============
+
+What's New
 -------------------
+Initial release of the **IBM z/OS CICS collection**, also referred to as **ibm_zos_cics**, which is part of the broader offering **Red Hat® Ansible Certified Content for IBM Z®**.
 
-Notes
-  * Initial release of IBM z/OS CICS collection, referred to as ibm_zos_cics which is part of the broader offering Red Hat® Ansible Certified Content for IBM Z.
-  * New modules
+This collection can manage CICS resources and definitions by calling the `CMCI REST API`_, which can be configured in a CICSplex or in a stand-alone region.
 
-    * cics_csd_process, cics_local_catalog_initialization, cics_global_catalog_processing, cics_cmci
-  * New documentation
-  * New sample playbook
+* Modules
+
+  * ``cmci_create`` - Create definitional CICS and CICSPlex® SM resources in CICS regions, using the CMCI REST API.
+  * ``cmci_delete`` - Delete installed and definitional CICS and CICSPlex® SM resources from CICS regions, using the CMCI REST API.
+  * ``cmci_get`` - Get information about installed and definitional CICS and CICSPlex® SM resources from CICS regions, using the CMCI REST API.
+  * ``cmci_install`` - Install CICS and CICSPlex® SM resources into CICS regions from definitions, using the CMCI REST API.
+  * ``cmci_update`` - Make changes to CICS and CICSPlex® SM resources in CICS regions using the CMCI REST API.
+
+
+* Documentation
+
+  * Generic documentation is available at `the documentation site`_, covering guidance on installation, modules, and other reference.
+
+  * Documentation related to playbook configuration is provided with sample playbooks at the `samples repository`_. Each playbook contains a README that explains what configurations must be made to run a sample playbook.
+
+
+* Playbooks
+
+  * Sample playbooks are available at the `samples repository`_. Each playbook contains a README that explains what configurations must be made to run a sample playbook.
+
+.. _samples repository:
+   https://github.com/IBM/z_ansible_collections_samples/blob/master/README.md
+
+.. _CMCI REST API:
+   https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/fundamentals/cpsm/cpsm-cmci-restfulapi-overview.html
+
+.. _the documentation site:
+   https://ansible-collections.github.io/ibm_zos_cics/
 
 Availability
-  * Galaxy
-  * GitHub
+------------
+
+* `Galaxy`_
+* `GitHub`_
+
+.. _GitHub:
+   https://github.com/ansible-collections/ibm_zos_cics
+
+.. _Galaxy:
+   https://galaxy.ansible.com/ibm/ibm_zos_cics
+
 
 Reference
-  * Supported by IBM z/OS core collection 1.0.0 or later
+---------
+
+* Supported by IBM CICS V4.2 or later
 

--- a/docs/source/requirements.rst
+++ b/docs/source/requirements.rst
@@ -6,23 +6,19 @@
 Requirements
 ============
 
-A control node is any machine with Ansible installed. From the control node,
-you can run commands and playbooks from a laptop, desktop, or server.
-However, you cannot run **IBM z/OS CICS collection** on a Windows system.
-
-A managed node is often referred to as a target node, or host, and it is managed
-by Ansible. Ansible need not be installed on a managed node, but SSH must be
-enabled.
-
 The nodes listed below require these specific versions of software:
 
 Control node
 ------------
 
+A control node is any machine with Ansible installed. From the control node,
+you can run commands and playbooks from a laptop, desktop, or server.
+
+.. note:: The IBM z/OS CICS collection cannot run on a Windows system.
+
 * `Ansible version`_: 2.9 or later
 * `Python`_: 2.7 or later
 * `OpenSSH`_
-* `IBM z/OS core collection`_
 
 .. _Ansible version:
    https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html
@@ -30,56 +26,15 @@ Control node
    https://www.python.org/downloads/release/latest
 .. _OpenSSH:
    https://www.openssh.com/
-.. _IBM z/OS core collection:
-   https://ansible-collections.github.io/ibm_zos_core/index.html
 
 
 Managed node
 ------------
 
-* `Python on z/OS`_: 3.6 or later
-* `z/OS`_: V02.02.00 or later
-* `z/OS OpenSSH`_
-* `IBM CICS V4.2 or later`_
-
-.. _Python on z/OS:
-   requirements.html#id1
-
-.. _z/OS:
-   https://www.ibm.com/support/knowledgecenter/SSLTBW_2.2.0/com.ibm.zos.v2r2/zos-v2r2-home.html
-
-.. _z/OS OpenSSH:
-   https://www.ibm.com/support/knowledgecenter/SSLTBW_2.2.0/com.ibm.zos.v2r2.e0za100/ch1openssh.htm
-
-.. _IBM CICS V4.2 or later:
-   https://www.ibm.com/support/knowledgecenter/SSGMCP_4.2.0/com.ibm.cics.ts.home.doc/welcomePage/welcomePage.html
-
-.. _release notes:
-   release_notes.html
-
-Python on z/OS
---------------
-
-If the Ansible target is z/OS, you must install a Python distribution ported
-for this platform. Rocket Software is currently the preferred version for z/OS.
-
-**Installation**
-
-* Visit the `Rocket Software homepage`_ and create a required account in the
-  `Rocket Customer Portal`_.
-* Click Downloads on the top left portion the page.
-* Select the category z/OpenSource on the left panel.
-* Scroll and select Python.
-* Download the binaries, installation files, and the README.ZOS onto an x86
-  machine.
-* Transfer the zipped tarball (tar.gz) file to the target z/OS system and
-  extract it according to the instructions in the installation files.
-* Follow the additional setup instructions as described in the README.ZOS file.
-
-.. _Rocket Software homepage:
-   https://www.rocketsoftware.com/zos-open-source
-.. _Rocket Customer Portal:
-   https://my.rocketsoftware.com/
+Ansible needs not be installed on a managed node, but SSH must be enabled. The CICS collection also requires a CMCI connection to either a CICSPlex SM or a stand-alone CICS region. For detailed requirements, see :doc:`requirements_managed`.
 
 
+.. toctree::
+   :maxdepth: 3
 
+   requirements_managed

--- a/docs/source/requirements_managed.rst
+++ b/docs/source/requirements_managed.rst
@@ -1,0 +1,28 @@
+.. ...........................................................................
+.. © Copyright IBM Corporation 2020                                          .
+.. ...........................................................................
+
+Requirements of managed nodes
+=============================
+
+The managed z/OS node is the host that is managed by Ansible, as identified in the Ansible inventory.
+
+The IBM z/OS CICS collection calls the `CMCI REST API`_ of CICS to perform tasks in CICS. Therefore, it doesn't require Python to be installed on the managed node when used alone.
+
+* `z/OS OpenSSH`_
+* IBM CICS V4.2 or later
+* `CMCI connection`_ must be set up in either a CICSPlex SM or a stand-alone CICS region
+
+If you want to use the CICS collection in conjunction with other IBM z/OS collections, you must follow their specific requirements, for example, `IBM z/OS core managed node requirements`_.
+
+.. _z/OS OpenSSH:
+   https://www.ibm.com/support/knowledgecenter/SSLTBW_2.2.0/com.ibm.zos.v2r2.e0za100/ch1openssh.htm
+
+.. _CMCI connection:
+   https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/configuring/cmci/clientapi_setup.html
+
+.. _CMCI REST API:
+   https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/fundamentals/cpsm/cpsm-cmci-restfulapi-overview.html
+
+.. _IBM z/OS core managed node requirements:
+   https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/requirements_managed.html


### PR DESCRIPTION
https://github.ibm.com/CICS/ansible-collections_ibm_zos_cics/pull/30

update readme to link to the new contributing guidelines.
restructured the ansible doc source following ims/zos core's suit:

created a new ansible_content.rst
created requirements_managed.rst
Updated installation, requirements (updated python dependencies list for CICS; removed verbose, unnecessary info and point to z/OS core doc instead)