### PR TITLE
Remove security type, replace with scheme

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,6 +10,9 @@ version: 1.0.0
 # Collection README file
 readme: README.md
 
+# Contributors
+authors:
+  - IBM
 # Description
 description: The Red Hat Ansible Certified Content for IBM Z CICS collection includes connection plugins, action plugins, modules and sample playbooks to automate tasks for CICS
 

--- a/tests/integration/targets/cics_cmci/playbooks/cics_cmci.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cics_cmci.yml
@@ -19,7 +19,6 @@
       cmci_password: '{{ cmci_password }}'
       context: '{{ context }}'
       scope: '{{ scope }}'
-      security_type: 'basic'
 
     ibm.ibm_zos_cics.cmci_update:
       cmci_host: '{{ cmci_host }}'
@@ -28,7 +27,6 @@
       cmci_password: '{{ cmci_password }}'
       context: '{{ context }}'
       scope: '{{ scope }}'
-      security_type: 'basic'
 
 
     ibm.ibm_zos_cics.cmci_delete:
@@ -38,7 +36,6 @@
       cmci_password: '{{ cmci_password }}'
       context: '{{ context }}'
       scope: '{{ scope }}'
-      security_type: 'basic'
 
 
     ibm.ibm_zos_cics.cmci_action:
@@ -48,7 +45,6 @@
       cmci_password: '{{ cmci_password }}'
       context: '{{ context }}'
       scope: '{{ scope }}'
-      security_type: 'basic'
 
 
     ibm.ibm_zos_cics.cmci_create:
@@ -58,7 +54,6 @@
       cmci_password: '{{ cmci_password }}'
       context: '{{ context }}'
       scope: '{{ scope }}'
-      security_type: 'basic'
 
   tasks:
     - name: 'Delete progdef'

--- a/tests/unit/helpers/cmci_helper.py
+++ b/tests/unit/helpers/cmci_helper.py
@@ -49,7 +49,7 @@ class CMCITestHelper:
             **kwargs
         )
 
-    def stub_cmci(self, method, resource_type, scheme='http', host=HOST, port=PORT,
+    def stub_cmci(self, method, resource_type, scheme='https', host=HOST, port=PORT,
                   context=CONTEXT, scope=None, parameters='', response_dict=None,
                   headers={'CONTENT-TYPE': 'application/xml'}, status_code=200, reason='OK',
                   record_count=None, **kwargs):

--- a/tests/unit/modules/test_cmci_action.py
+++ b/tests/unit/modules/test_cmci_action.py
@@ -34,7 +34,7 @@ def test_csd_install(cmci_module):  # type: (CMCITestHelper) -> None
     )
 
     cmci_module.expect(result(
-        'http://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/'
+        'https://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/'
         'cicsdefinitionbundle/CICSEX56/IYCWEMW2?PARAMETER=CSDGROUP%28%2A%29',
         record,
         '<request><action name="CSDINSTALL"></action></request>'
@@ -73,7 +73,7 @@ def test_bas_install(cmci_module):  # type: (CMCITestHelper) -> None
     )
 
     cmci_module.expect(result(
-        'http://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/cicsdefinitionbundle/CICSEX56/',
+        'https://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/cicsdefinitionbundle/CICSEX56/',
         record,
         '<request><action name="INSTALL"></action></request>'
     ))
@@ -112,7 +112,7 @@ def test_install_csd_criteria_parameter(cmci_module):  # type: (CMCITestHelper) 
     )
 
     cmci_module.expect(result(
-        'http://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/cicsdefinitionprogram/'
+        'https://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/cicsdefinitionprogram/'
         'CICSEX56/IYCWEMW2?CRITERIA=%28NAME%3D%27DUMMY%27%29%20AND%20%28DEFVER%3D%270%27%29%20AND'
         '%20%28CSDGROUP%3D%27DUMMY%27%29&PARAMETER=CSDGROUP%28DUMMY%29',
         record,
@@ -123,7 +123,6 @@ def test_install_csd_criteria_parameter(cmci_module):  # type: (CMCITestHelper) 
         'cmci_port': PORT,
         'context': CONTEXT,
         'scope': SCOPE,
-        'security_type': 'none',
         'type': 'cicsdefinitionprogram',
         'action_name': 'CSDINSTALL',
         'resources': {
@@ -176,7 +175,7 @@ def test_bas_install_params(cmci_module):  # type: (CMCITestHelper) -> None
     )
 
     cmci_module.expect(result(
-        'http://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/cicsdefinitionbundle/CICSEX56/',
+        'https://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/cicsdefinitionbundle/CICSEX56/',
         record,
         '<request><action name="INSTALL">'
         '<parameter name="FORCEINS" value="NO"></parameter>'

--- a/tests/unit/modules/test_cmci_create.py
+++ b/tests/unit/modules/test_cmci_create.py
@@ -42,7 +42,7 @@ def test_csd_create(cmci_module):  # type: (CMCITestHelper) -> None
     cmci_module.expect({
         'changed': True,
         'request': {
-            'url': 'http://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/'
+            'url': 'https://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/'
                    'cicsdefinitionbundle/CICSEX56/IYCWEMW2',
             'method': 'POST',
             'body': '<request><create>'

--- a/tests/unit/modules/test_cmci_delete.py
+++ b/tests/unit/modules/test_cmci_delete.py
@@ -17,7 +17,7 @@ def test_delete_context(cmci_module):  # type: (CMCITestHelper) -> None
 
     cmci_module.expect(
         result(
-            'http://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/cicsdefinitionbundle/CICSEX56/',
+            'https://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/cicsdefinitionbundle/CICSEX56/',
             1
         )
     )
@@ -35,7 +35,7 @@ def test_delete_context_scope(cmci_module):  # type: (CMCITestHelper) -> None
 
     cmci_module.expect(
         result(
-            'http://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/cicsdefinitionbundle/CICSEX56/IYCWEMW2',
+            'https://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/cicsdefinitionbundle/CICSEX56/IYCWEMW2',
             1
         )
     )
@@ -54,7 +54,7 @@ def test_delete_criteria(cmci_module):  # type: (CMCITestHelper) -> None
 
     cmci_module.expect(
         result(
-            'http://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/'
+            'https://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/'
             'cicsdefinitionbundle/CICSEX56/?CRITERIA=%28FOO%3D%27BAR%27%29',
             1
         )
@@ -78,7 +78,7 @@ def test_delete_parameter(cmci_module):  # type: (CMCITestHelper) -> None
 
     cmci_module.expect(
         result(
-            'http://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/'
+            'https://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/'
             'cicsdefinitionbundle/CICSEX56/?PARAMETER=CSDGROUP%28%2A%29',
             1
         )
@@ -104,7 +104,7 @@ def test_delete_criteria_parameter(cmci_module):  # type: (CMCITestHelper) -> No
 
     cmci_module.expect(
         result(
-            'http://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/'
+            'https://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/'
             'cicsdefinitionbundle/CICSEX56/?CRITERIA=%28FOO%3D%27BAR%27%29&PARAMETER=CSDGROUP%28%2A%29',
             1
         )

--- a/tests/unit/modules/test_cmci_filters.py
+++ b/tests/unit/modules/test_cmci_filters.py
@@ -22,7 +22,7 @@ def test_query_criteria(cmci_module):  # type: (CMCITestHelper) -> None
     cmci_module.stub_records('GET', 'cicslocalfile', records, scope=SCOPE, parameters='?CRITERIA=%28FOO%3D%27BAR%27%29')
 
     cmci_module.expect(result(
-        'http://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/'
+        'https://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/'
         'cicslocalfile/CICSEX56/IYCWEMW2?CRITERIA=%28FOO%3D%27BAR%27%29',
         records=records
     ))
@@ -47,7 +47,7 @@ def test_filter_multi(cmci_module):  # type: (CMCITestHelper) -> None
                              parameters='?CRITERIA=%28FOO%3D%27BAR%27%29%20AND%20%28GOO%3D%27LAR%27%29')
 
     cmci_module.expect(result(
-        'http://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/'
+        'https://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/'
         'cicslocalfile/CICSEX56/IYCWEMW2?CRITERIA=%28FOO%3D%27BAR%27%29%20AND%20%28GOO%3D%27LAR%27%29',
         records=records
     ))
@@ -73,7 +73,7 @@ def test_complex_filter_and(cmci_module):  # type: (CMCITestHelper) -> None
                              parameters='?CRITERIA=%28FOO%3D%27BAR%27%29%20AND%20%28GOO%3D%27LAR%27%29')
 
     cmci_module.expect(result(
-        'http://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/'
+        'https://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/'
         'cicslocalfile/CICSEX56/IYCWEMW2?CRITERIA=%28FOO%3D%27BAR%27%29%20AND%20%28GOO%3D%27LAR%27%29',
         records=records
     ))
@@ -107,7 +107,7 @@ def test_complex_filter_or(cmci_module):  # type: (CMCITestHelper) -> None
                              parameters='?CRITERIA=%28FOO%3D%27BAR%27%29%20OR%20%28GOO%3D%27LAR%27%29')
 
     cmci_module.expect(result(
-        'http://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/'
+        'https://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/'
         'cicslocalfile/CICSEX56/IYCWEMW2?CRITERIA=%28FOO%3D%27BAR%27%29%20OR%20%28GOO%3D%27LAR%27%29',
         records=records
     ))
@@ -143,7 +143,7 @@ def test_complex_filter_operator(cmci_module):  # type: (CMCITestHelper) -> None
                              parameters='?CRITERIA=%28FOO%C2%AC%3D%27BAR%27%29')
 
     cmci_module.expect(result(
-        'http://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/'
+        'https://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/'
         'cicslocalfile/CICSEX56/IYCWEMW2?CRITERIA=%28FOO%C2%AC%3D%27BAR%27%29',
         records=records
     ))
@@ -171,7 +171,7 @@ def test_complex_filter_and_or(cmci_module):  # type: (CMCITestHelper) -> None
                                         '%28BING%3D%271%27%29%20OR%20%28BING%3D%272%27%29%29')
 
     cmci_module.expect(result(
-        'http://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/'
+        'https://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/'
         'cicslocalfile/CICSEX56/IYCWEMW2?CRITERIA=%28FOO%3D%27BAR%27%29%20AND%20%28BAT%3D%27BAZ%27%29%20AND%20%28'
         '%28BING%3D%271%27%29%20OR%20%28BING%3D%272%27%29%29',
         records=records
@@ -213,7 +213,7 @@ def test_complex_filter_and_and(cmci_module):  # type: (CMCITestHelper) -> None
                                         '%28BING%3D%271%27%29%20AND%20%28BING%3D%272%27%29%29')
 
     cmci_module.expect(result(
-        'http://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/'
+        'https://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/'
         'cicslocalfile/CICSEX56/IYCWEMW2?CRITERIA=%28FOO%3D%27BAR%27%29%20AND%20%28BAT%3D%3D%27BAZ%27%29%20AND%20%28'
         '%28BING%3D%271%27%29%20AND%20%28BING%3D%272%27%29%29',
         records=records
@@ -257,7 +257,7 @@ def test_complex_filter_or_or(cmci_module):  # type: (CMCITestHelper) -> None
                                         '%28BING%3D%272%27%29%29')
 
     cmci_module.expect(result(
-        'http://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/'
+        'https://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/'
         'cicslocalfile/CICSEX56/IYCWEMW2?CRITERIA=%28FOO%3E%3D%27BAR%27%29%20OR%20%28%28BING%3D%3D%271%27%29%20OR%20'
         '%28BING%3D%272%27%29%29',
         records=records
@@ -360,7 +360,7 @@ def test_complex_filter_operator_letters(cmci_module):  # type: (CMCITestHelper)
     cmci_module.stub_records('GET', 'cicslocalfile', records, scope=SCOPE, parameters='?CRITERIA=%28FOO%3E%27BAR%27%29')
 
     cmci_module.expect(result(
-        'http://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/'
+        'https://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/'
         'cicslocalfile/CICSEX56/IYCWEMW2?CRITERIA=%28FOO%3E%27BAR%27%29',
         records=records
     ))

--- a/tests/unit/modules/test_cmci_update.py
+++ b/tests/unit/modules/test_cmci_update.py
@@ -41,7 +41,7 @@ def test_update(cmci_module):  # type: (CMCITestHelper) -> None
     )
 
     cmci_module.expect(result(
-        'http://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/cicsdefinitionprogram'
+        'https://winmvs2c.hursley.ibm.com:26040/CICSSystemManagement/cicsdefinitionprogram'
         '/CICSEX56/IYCWEMW2?CRITERIA=%28NAME%3D%27DUMMY%27%29&PARAMETER=CSDGROUP%28DUMMY%29',
         record,
         '<request><update>'
@@ -55,7 +55,6 @@ def test_update(cmci_module):  # type: (CMCITestHelper) -> None
         'cmci_port': PORT,
         'context': CONTEXT,
         'scope': SCOPE,
-        'security_type': 'none',
         'type': 'cicsdefinitionprogram',
         'parameters': [{
             'name': 'CSD'


### PR DESCRIPTION
Removed `security_type` which could be set to basic, cert or none.  None implied http, basic and cert both implied authenticated over https.  This made it impossible to do unauthenticated https, or authenticated http (which would certainly not be recommended, but we shouldn't make it impossible).

This PR replaces `security_type` with a parameter `scheme` which can be set to `http` or `https`, defaulting to `https`.  This means I've updated all the tests to account for the new default behaviour, as most of them are testing the unauthenticated pathway, and now that will default to https.

basic/cert auth is now derived from which properties are set from cmci_user, cmci_password, cmci_cert and cmci_key.  cmci_user and cmci_password are required together, as are cmci_cert and cmci_key.  I suspect there's probably a use case where we might consider supporting certificates that aren't protected by a key, but I haven't accounted for that here, and I'm not particularly worried about it.


All the authentication parameters are capable of being provided by environment variables, which are documented.  I've manually tested that the required behaviour plays nicely with that: I can supply a user in the yml, and a password in an environment variable.  However, I can't easily write an automated test for that kind of scenario because of the way ansible-test works, making it difficult to inject per-test environment variables.  Thinking about it, something might be possible, so I might come back to this after Christmas.

Authentication will prioritise cert/key if provided, then user/pass if provided, then unauthenticated.  I'll let Vera know that we should document this behaviour.  This does mean that people will have to make sure that cert/key are not set if they want to use user/password otherwise it'll always try that combination.  hopefully we're able to imply this in the documentation without explicitly stating it outright, as it's difficult to explain, and a pretty niche situation!
