### PR TITLE
Fix parameters doc indentation

### DIFF
--- a/docs/source/modules/cmci_action.rst
+++ b/docs/source/modules/cmci_action.rst
@@ -142,7 +142,7 @@ insecure
 
      
 parameters
-  A list of one or more parameters with optional values used to identify the resources for this request. Eligible parameters for identifying the target resources can be found in the resource table reference for the  target resource type, as valid parameters for the GET operation in the "Valid CPSM operations" table.  For example, the valid parameters for identifying a PROGDEF resource are CICSSYS, CSDGROUP and RESGROUP, as found in the `PROGDEF resource table reference <https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.6.0/reference-cpsm-restables/cpsm-restables/PROGDEFtab.html>`_.
+  A list of one or more parameters for the target operation.  TODO should we document this parameter separately for each operation?  E.g. might be easier to show how to find the parameters for an action distinct from create... TODO Provide an example of how to use flag style parameters
 
 
 
@@ -152,7 +152,7 @@ parameters
 
      
   name
-    Parameter name available for the GET operation.
+    Parameter name
 
 
     | **required**: True
@@ -161,7 +161,7 @@ parameters
 
      
   value
-    Parameter value if any.
+    Parameter value if any
 
 
     | **required**: False
@@ -239,6 +239,35 @@ resources
 
     | **required**: False
     | **type**: str
+
+
+     
+  parameters
+    A list of one or more parameters with optional values used to identify the resources for this request. Eligible parameters for identifying the target resources can be found in the resource table reference for the  target resource type, as valid parameters for the GET operation in the "Valid CPSM operations" table.  For example, the valid parameters for identifying a PROGDEF resource are CICSSYS, CSDGROUP and RESGROUP, as found in the `PROGDEF resource table reference <https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.6.0/reference-cpsm-restables/cpsm-restables/PROGDEFtab.html>`_.
+
+
+
+    | **required**: False
+    | **type**: list
+
+
+     
+    name
+      Parameter name available for the GET operation.
+
+
+      | **required**: True
+      | **type**: str
+
+
+     
+    value
+      Parameter value if any.
+
+
+      | **required**: False
+      | **type**: str
+
 
 
 

--- a/docs/source/modules/cmci_delete.rst
+++ b/docs/source/modules/cmci_delete.rst
@@ -132,7 +132,7 @@ insecure
 
      
 parameters
-  A list of one or more parameters with optional values used to identify the resources for this request. Eligible parameters for identifying the target resources can be found in the resource table reference for the  target resource type, as valid parameters for the GET operation in the "Valid CPSM operations" table.  For example, the valid parameters for identifying a PROGDEF resource are CICSSYS, CSDGROUP and RESGROUP, as found in the `PROGDEF resource table reference <https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.6.0/reference-cpsm-restables/cpsm-restables/PROGDEFtab.html>`_.
+  A list of one or more parameters for the target operation.  TODO should we document this parameter separately for each operation?  E.g. might be easier to show how to find the parameters for an action distinct from create... TODO Provide an example of how to use flag style parameters
 
 
 
@@ -142,7 +142,7 @@ parameters
 
      
   name
-    Parameter name available for the GET operation.
+    Parameter name
 
 
     | **required**: True
@@ -151,7 +151,7 @@ parameters
 
      
   value
-    Parameter value if any.
+    Parameter value if any
 
 
     | **required**: False
@@ -229,6 +229,35 @@ resources
 
     | **required**: False
     | **type**: str
+
+
+     
+  parameters
+    A list of one or more parameters with optional values used to identify the resources for this request. Eligible parameters for identifying the target resources can be found in the resource table reference for the  target resource type, as valid parameters for the GET operation in the "Valid CPSM operations" table.  For example, the valid parameters for identifying a PROGDEF resource are CICSSYS, CSDGROUP and RESGROUP, as found in the `PROGDEF resource table reference <https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.6.0/reference-cpsm-restables/cpsm-restables/PROGDEFtab.html>`_.
+
+
+
+    | **required**: False
+    | **type**: list
+
+
+     
+    name
+      Parameter name available for the GET operation.
+
+
+      | **required**: True
+      | **type**: str
+
+
+     
+    value
+      Parameter value if any.
+
+
+      | **required**: False
+      | **type**: str
+
 
 
 

--- a/docs/source/modules/cmci_get.rst
+++ b/docs/source/modules/cmci_get.rst
@@ -131,35 +131,6 @@ insecure
 
 
      
-parameters
-  A list of one or more parameters with optional values used to identify the resources for this request. Eligible parameters for identifying the target resources can be found in the resource table reference for the  target resource type, as valid parameters for the GET operation in the "Valid CPSM operations" table.  For example, the valid parameters for identifying a PROGDEF resource are CICSSYS, CSDGROUP and RESGROUP, as found in the `PROGDEF resource table reference <https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.6.0/reference-cpsm-restables/cpsm-restables/PROGDEFtab.html>`_.
-
-
-
-  | **required**: False
-  | **type**: list
-
-
-     
-  name
-    Parameter name available for the GET operation.
-
-
-    | **required**: True
-    | **type**: str
-
-
-     
-  value
-    Parameter value if any.
-
-
-    | **required**: False
-    | **type**: str
-
-
-
-     
 record_count
   Identifies a subset of records in the results cache, starting either from the first record in the results cache or from the record specified by the index parameter.
 
@@ -242,6 +213,35 @@ resources
 
     | **required**: False
     | **type**: str
+
+
+     
+  parameters
+    A list of one or more parameters with optional values used to identify the resources for this request. Eligible parameters for identifying the target resources can be found in the resource table reference for the  target resource type, as valid parameters for the GET operation in the "Valid CPSM operations" table.  For example, the valid parameters for identifying a PROGDEF resource are CICSSYS, CSDGROUP and RESGROUP, as found in the `PROGDEF resource table reference <https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.6.0/reference-cpsm-restables/cpsm-restables/PROGDEFtab.html>`_.
+
+
+
+    | **required**: False
+    | **type**: list
+
+
+     
+    name
+      Parameter name available for the GET operation.
+
+
+      | **required**: True
+      | **type**: str
+
+
+     
+    value
+      Parameter value if any.
+
+
+      | **required**: False
+      | **type**: str
+
 
 
 

--- a/docs/source/modules/cmci_update.rst
+++ b/docs/source/modules/cmci_update.rst
@@ -141,7 +141,7 @@ insecure
 
      
 parameters
-  A list of one or more parameters with optional values used to identify the resources for this request. Eligible parameters for identifying the target resources can be found in the resource table reference for the  target resource type, as valid parameters for the GET operation in the "Valid CPSM operations" table.  For example, the valid parameters for identifying a PROGDEF resource are CICSSYS, CSDGROUP and RESGROUP, as found in the `PROGDEF resource table reference <https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.6.0/reference-cpsm-restables/cpsm-restables/PROGDEFtab.html>`_.
+  A list of one or more parameters for the target operation.  TODO should we document this parameter separately for each operation?  E.g. might be easier to show how to find the parameters for an action distinct from create... TODO Provide an example of how to use flag style parameters
 
 
 
@@ -151,7 +151,7 @@ parameters
 
      
   name
-    Parameter name available for the GET operation.
+    Parameter name
 
 
     | **required**: True
@@ -160,7 +160,7 @@ parameters
 
      
   value
-    Parameter value if any.
+    Parameter value if any
 
 
     | **required**: False
@@ -238,6 +238,35 @@ resources
 
     | **required**: False
     | **type**: str
+
+
+     
+  parameters
+    A list of one or more parameters with optional values used to identify the resources for this request. Eligible parameters for identifying the target resources can be found in the resource table reference for the  target resource type, as valid parameters for the GET operation in the "Valid CPSM operations" table.  For example, the valid parameters for identifying a PROGDEF resource are CICSSYS, CSDGROUP and RESGROUP, as found in the `PROGDEF resource table reference <https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.6.0/reference-cpsm-restables/cpsm-restables/PROGDEFtab.html>`_.
+
+
+
+    | **required**: False
+    | **type**: list
+
+
+     
+    name
+      Parameter name available for the GET operation.
+
+
+      | **required**: True
+      | **type**: str
+
+
+     
+    value
+      Parameter value if any.
+
+
+      | **required**: False
+      | **type**: str
+
 
 
 

--- a/plugins/doc_fragments/cmci.py
+++ b/plugins/doc_fragments/cmci.py
@@ -171,25 +171,25 @@ options:
                 resource table reference, for example, L(PROGDEF resource table reference,
                 https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.6.0/reference-cpsm-restables/cpsm-restables/PROGDEFtab.html).
             required: false
-  parameters:
-    description: >
-      A list of one or more parameters with optional values used to identify the resources for this request.
-      Eligible parameters for identifying the target resources can be found in the resource table reference for the 
-      target resource type, as valid parameters for the GET operation in the "Valid CPSM operations" table. 
-      For example, the valid parameters for identifying a PROGDEF resource are
-      CICSSYS, CSDGROUP and RESGROUP, as found in the L(PROGDEF resource table reference,
-      https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.6.0/reference-cpsm-restables/cpsm-restables/PROGDEFtab.html).
-    type: list
-    suboptions:
-      name:
-        description: Parameter name available for the GET operation.
-        required: true
-        type: str
-      value:
-        description: Parameter value if any.
+      parameters:
+        description: >
+          A list of one or more parameters with optional values used to identify the resources for this request.
+          Eligible parameters for identifying the target resources can be found in the resource table reference for the 
+          target resource type, as valid parameters for the GET operation in the "Valid CPSM operations" table. 
+          For example, the valid parameters for identifying a PROGDEF resource are
+          CICSSYS, CSDGROUP and RESGROUP, as found in the L(PROGDEF resource table reference,
+          https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.6.0/reference-cpsm-restables/cpsm-restables/PROGDEFtab.html).
+        type: list
+        suboptions:
+          name:
+            description: Parameter name available for the GET operation.
+            required: true
+            type: str
+          value:
+            description: Parameter value if any.
+            required: false
+            type: str
         required: false
-        type: str
-    required: false
 '''
 
     ATTRIBUTES = r'''


### PR DESCRIPTION
Parameters documentation was badly indented, which meant only one flavour of the indentation ended up in the generated documentation because of how Ansible merges documentation fragments.  This corrects that, and regenerates the documentation, where you should see parameters twice now, for eligible segments.