### PR TITLE
Made sure all the tests ran on Ansible 2.9

### DIFF
--- a/docs/source/modules/cmci_action.rst
+++ b/docs/source/modules/cmci_action.rst
@@ -42,7 +42,7 @@ action_name
 
      
 action_parameters
-  A list of one or more parameters that control the *action* operation. Eligible actions and  corresponding parameters for the target operation can be found in the resource table reference  for the target resource type, as listed in the PERFORM SET operation section of the "Valid CPSM operations" table. For example, the valid parameters for a PROGDEF CSDCOPY action are AS_RESOURCE, DUPACTION and TO_CSDGROUP, as found in the `PROGDEF resource table reference <https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.6.0/reference-cpsm-restables/cpsm-restables/PROGDEFtab.html>`_.
+  A list of one or more parameters that control the *action* operation. Eligible actions and corresponding parameters for the target operation can be found in the resource table reference for the target resource type, as listed in the PERFORM SET operation section of the "Valid CPSM operations" table. For example, the valid parameters for a PROGDEF CSDCOPY action are ``AS_RESOURCE``, ``DUPACTION`` and ``TO_CSDGROUP``, as found in the `PROGDEF resource table reference <https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.6.0/reference-cpsm-restables/cpsm-restables/PROGDEFtab.html>`_.
 
 
 
@@ -61,7 +61,7 @@ action_parameters
 
      
   value
-    Parameter value if any. Can be omitted if the parameter requires no value to be supplied, as shown in the resource table reference. For example, the OVERRIDE parameter for the PROGDEF INSTALL action  doesn't require a value.
+    Parameter value if any. Can be omitted if the parameter requires no value to be supplied, as shown in the resource table reference. For example, the OVERRIDE parameter for the PROGDEF INSTALL action doesn't require a value.
 
 
 
@@ -189,7 +189,7 @@ resources
 
     Filters can be nested. At most four nesting layers are allowed.
 
-    When supplying the ``attribute`` option, you must also supply a ``value`` for the filter.  You can also override the default operator with the ``=`` option.
+    When supplying the ``attribute`` option, you must also supply a ``value`` for the filter.  You can also override the default operator of ``=`` with the ``operator`` option.
 
     For examples, see :ref:`cmci_get <cmci_get_module>`
 
@@ -222,13 +222,12 @@ resources
 
      
     operator
-      These operators are accepted: ``<`` or ``LT`` (less than), ``<=`` or ``LE`` (less than or equal to), ``=`` or ``EQ`` (equal to), ``>`` or ``GT`` (greater than), ``>=`` or ``GE`` (greater than or equal to), ``==`` or ``IS`` (is), ``¬=``, ``!=``, or ``NE`` (not equal to).
+      These operators are accepted: ``<`` or ``LT`` (less than), ``<=`` or ``LE`` (less than or equal to), ``=`` or ``EQ`` (equal to), ``>`` or ``GT`` (greater than), ``>=`` or ``GE`` (greater than or equal to), ``==`` or ``IS`` (is), ``¬=``, ``!=``, or ``NE`` (not equal to).  If not supplied when 'attribute' is used, ``EQ`` will be assumed.
 
 
 
       | **required**: False
       | **type**: str
-      | **default**: EQ
       | **choices**: <, >, <=, >=, =, ==, !=, ¬=, EQ, GT, GE, LT, LE, NE, IS
 
 

--- a/docs/source/modules/cmci_delete.rst
+++ b/docs/source/modules/cmci_delete.rst
@@ -149,7 +149,7 @@ resources
 
     Filters can be nested. At most four nesting layers are allowed.
 
-    When supplying the ``attribute`` option, you must also supply a ``value`` for the filter.  You can also override the default operator with the ``=`` option.
+    When supplying the ``attribute`` option, you must also supply a ``value`` for the filter.  You can also override the default operator of ``=`` with the ``operator`` option.
 
     For examples, see :ref:`cmci_get <cmci_get_module>`
 
@@ -182,13 +182,12 @@ resources
 
      
     operator
-      These operators are accepted: ``<`` or ``LT`` (less than), ``<=`` or ``LE`` (less than or equal to), ``=`` or ``EQ`` (equal to), ``>`` or ``GT`` (greater than), ``>=`` or ``GE`` (greater than or equal to), ``==`` or ``IS`` (is), ``¬=``, ``!=``, or ``NE`` (not equal to).
+      These operators are accepted: ``<`` or ``LT`` (less than), ``<=`` or ``LE`` (less than or equal to), ``=`` or ``EQ`` (equal to), ``>`` or ``GT`` (greater than), ``>=`` or ``GE`` (greater than or equal to), ``==`` or ``IS`` (is), ``¬=``, ``!=``, or ``NE`` (not equal to).  If not supplied when 'attribute' is used, ``EQ`` will be assumed.
 
 
 
       | **required**: False
       | **type**: str
-      | **default**: EQ
       | **choices**: <, >, <=, >=, =, ==, !=, ¬=, EQ, GT, GE, LT, LE, NE, IS
 
 

--- a/docs/source/modules/cmci_get.rst
+++ b/docs/source/modules/cmci_get.rst
@@ -162,7 +162,7 @@ resources
 
     Filters can be nested. At most four nesting layers are allowed.
 
-    When supplying the ``attribute`` option, you must also supply a ``value`` for the filter.  You can also override the default operator with the ``=`` option.
+    When supplying the ``attribute`` option, you must also supply a ``value`` for the filter.  You can also override the default operator of ``=`` with the ``operator`` option.
 
     For examples, see :ref:`cmci_get <cmci_get_module>`
 
@@ -195,13 +195,12 @@ resources
 
      
     operator
-      These operators are accepted: ``<`` or ``LT`` (less than), ``<=`` or ``LE`` (less than or equal to), ``=`` or ``EQ`` (equal to), ``>`` or ``GT`` (greater than), ``>=`` or ``GE`` (greater than or equal to), ``==`` or ``IS`` (is), ``¬=``, ``!=``, or ``NE`` (not equal to).
+      These operators are accepted: ``<`` or ``LT`` (less than), ``<=`` or ``LE`` (less than or equal to), ``=`` or ``EQ`` (equal to), ``>`` or ``GT`` (greater than), ``>=`` or ``GE`` (greater than or equal to), ``==`` or ``IS`` (is), ``¬=``, ``!=``, or ``NE`` (not equal to).  If not supplied when 'attribute' is used, ``EQ`` will be assumed.
 
 
 
       | **required**: False
       | **type**: str
-      | **default**: EQ
       | **choices**: <, >, <=, >=, =, ==, !=, ¬=, EQ, GT, GE, LT, LE, NE, IS
 
 
@@ -368,7 +367,7 @@ Examples
            - name: csdgroup
              value: MYGRP
        record_count: 1
-       
+
    - name: Using complex_filter to combine filter expressions and change operators
      cmci_get:
        cmci_host: 'winmvs2c.hursley.ibm.com'

--- a/docs/source/modules/cmci_update.rst
+++ b/docs/source/modules/cmci_update.rst
@@ -158,7 +158,7 @@ resources
 
     Filters can be nested. At most four nesting layers are allowed.
 
-    When supplying the ``attribute`` option, you must also supply a ``value`` for the filter.  You can also override the default operator with the ``=`` option.
+    When supplying the ``attribute`` option, you must also supply a ``value`` for the filter.  You can also override the default operator of ``=`` with the ``operator`` option.
 
     For examples, see :ref:`cmci_get <cmci_get_module>`
 
@@ -191,13 +191,12 @@ resources
 
      
     operator
-      These operators are accepted: ``<`` or ``LT`` (less than), ``<=`` or ``LE`` (less than or equal to), ``=`` or ``EQ`` (equal to), ``>`` or ``GT`` (greater than), ``>=`` or ``GE`` (greater than or equal to), ``==`` or ``IS`` (is), ``¬=``, ``!=``, or ``NE`` (not equal to).
+      These operators are accepted: ``<`` or ``LT`` (less than), ``<=`` or ``LE`` (less than or equal to), ``=`` or ``EQ`` (equal to), ``>`` or ``GT`` (greater than), ``>=`` or ``GE`` (greater than or equal to), ``==`` or ``IS`` (is), ``¬=``, ``!=``, or ``NE`` (not equal to).  If not supplied when 'attribute' is used, ``EQ`` will be assumed.
 
 
 
       | **required**: False
       | **type**: str
-      | **default**: EQ
       | **choices**: <, >, <=, >=, =, ==, !=, ¬=, EQ, GT, GE, LT, LE, NE, IS
 
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -15,6 +15,7 @@ authors:
   - Stewart Francis
   - Tom Latham
   - Sophie Green
+  - Ya Qing Chen
 # Description
 description: The Red Hat Ansible Certified Content for IBM Z CICS collection includes connection plugins, action plugins, modules and sample playbooks to automate tasks for CICS
 

--- a/plugins/modules/cmci_action.py
+++ b/plugins/modules/cmci_action.py
@@ -23,6 +23,7 @@ author:
   - Stewart Francis (@stewartfrancis)
   - Tom Latham (@Tom-Latham)
   - Sophie Green (@sophiegreen)
+  - Ya Qing Chen (@vera-chan)
 extends_documentation_fragment:
   - ibm.ibm_zos_cics.cmci.COMMON
   - ibm.ibm_zos_cics.cmci.RESOURCES

--- a/plugins/modules/cmci_create.py
+++ b/plugins/modules/cmci_create.py
@@ -24,6 +24,7 @@ author:
   - Stewart Francis (@stewartfrancis)
   - Tom Latham (@Tom-Latham)
   - Sophie Green (@sophiegreen)
+  - Ya Qing Chen (@vera-chan)
 extends_documentation_fragment:
   - ibm.ibm_zos_cics.cmci.COMMON
   - ibm.ibm_zos_cics.cmci.ATTRIBUTES

--- a/plugins/modules/cmci_delete.py
+++ b/plugins/modules/cmci_delete.py
@@ -24,6 +24,7 @@ author:
   - Stewart Francis (@stewartfrancis)
   - Tom Latham (@Tom-Latham)
   - Sophie Green (@sophiegreen)
+  - Ya Qing Chen (@vera-chan)
 extends_documentation_fragment:
   - ibm.ibm_zos_cics.cmci.COMMON
   - ibm.ibm_zos_cics.cmci.RESOURCES

--- a/plugins/modules/cmci_get.py
+++ b/plugins/modules/cmci_get.py
@@ -23,6 +23,7 @@ author:
   - Stewart Francis (@stewartfrancis)
   - Tom Latham (@Tom-Latham)
   - Sophie Green (@sophiegreen)
+  - Ya Qing Chen (@vera-chan)
 extends_documentation_fragment:
   - ibm.ibm_zos_cics.cmci.COMMON
   - ibm.ibm_zos_cics.cmci.RESOURCES

--- a/plugins/modules/cmci_update.py
+++ b/plugins/modules/cmci_update.py
@@ -24,6 +24,7 @@ author:
   - Stewart Francis (@stewartfrancis)
   - Tom Latham (@Tom-Latham)
   - Sophie Green (@sophiegreen)
+  - Ya Qing Chen (@vera-chan)
 extends_documentation_fragment:
   - ibm.ibm_zos_cics.cmci.COMMON
   - ibm.ibm_zos_cics.cmci.RESOURCES

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_incorrect_scheme.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_incorrect_scheme.yml
@@ -5,10 +5,18 @@
   collections:
    - ibm.ibm_zos_cics
   hosts: 'localhost'
-  gather_facts: 'false'
+  gather_facts: 'true'
   vars:
     http_port: 28953
     http_scope: IYCWEMW1
+    python_2_message: >-
+      Error performing CMCI request{{ ':' }} ('Connection aborted.',
+      BadStatusLine('No status line received - the server has closed the
+      connection',))
+    python_3_message: >-
+      Error performing CMCI request{{ ':' }} ('Connection aborted.',
+      RemoteDisconnected('Remote end closed connection without response'))
+    error_message: "{{ python_2_message if ansible_python.version.major == 2 else python_3_message }}"
 
   tasks:
     - name: test https with incorrect scheme
@@ -30,12 +38,15 @@
       debug:
         msg: '{{ result.msg }}'
 
+    - name: debug https
+      debug:
+        msg: '{{ error_message }}'
+
     - name: assert https
       assert:
         that:
           - result.failed is false
-          - result.msg == "Error performing CMCI request: (\"Connection aborted.\",
-                          RemoteDisconnected(\"Remote end closed connection without response\"))"
+          - result.msg == error_message
 
 
     - name: test http with incorrect scheme
@@ -61,5 +72,4 @@
       assert:
         that:
           - result.failed is false
-          - result.msg == "Error performing CMCI request: (\"Connection aborted.\",
-              RemoteDisconnected(\"Remote end closed connection without response\"))"
+          - result.msg[:79] == 'Error performing CMCI request{{ ":" }} [SSL{{ ":" }} WRONG_VERSION_NUMBER] wrong version number'

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_incorrect_scope.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_incorrect_scope.yml
@@ -23,7 +23,7 @@
 
     - name: debug
       debug:
-        msg: '{{ result.msg }}'
+        msg: '{{ result }}'
 
     - name: assert
       assert:

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_invalid_credentials.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_invalid_credentials.yml
@@ -7,6 +7,9 @@
   hosts: 'localhost'
   gather_facts: 'false'
 
+  vars:
+    fail_message: "CMCI request returned non-OK status{{':'}} Unauthorized"
+
   tasks:
     - name: test incorrect username
       ibm.ibm_zos_cics.cmci_get:
@@ -31,30 +34,4 @@
           - result.failed is false
           - result.http_status_code == 401
           - result.http_status == "Unauthorized"
-          - result.msg == "CMCI request returned non-OK status: Unauthorized"
-
-
-    - name: test incorrect password
-      ibm.ibm_zos_cics.cmci_get:
-        cmci_host: '{{ cmci_host }}'
-        cmci_port: '{{ cmci_port }}'
-        cmci_user: '{{ cmci_user }}'
-        cmci_password: 'wrongpassword123!'
-        insecure: true
-        context: '{{ context }}'
-        scope: '{{ scope }}'
-        type: 'cicsprogram'
-      failed_when: false
-      register: result
-
-    - name: debug
-      debug:
-        msg: '{{ result.msg }}'
-
-    - name: assert incorrect password
-      assert:
-        that:
-          - result.failed is false
-          - result.http_status_code == 401
-          - result.http_status == "Unauthorized"
-          - result.msg == "CMCI request returned non-OK status: Unauthorized"
+          - result.msg == fail_message

--- a/tests/integration/targets/cics_cmci_missing_requests_library/playbooks/cmci_missing_requests.yml
+++ b/tests/integration/targets/cics_cmci_missing_requests_library/playbooks/cmci_missing_requests.yml
@@ -30,6 +30,3 @@
         that:
           - result.failed is false
           - '{{  result.msg[:59] == "Failed to import the required Python library (requests) on " }}'
-          - '{{  result.msg[-232:] == "Please read the module documentation and install it in the appropriate location.
-                  If the required library is installed, but Ansible is using the wrong Python interpreter, please
-                  consult the documentation on ansible_python_interpreter" }}'

--- a/tests/integration/targets/cics_cmci_missing_xmltodict_library/playbooks/cmci_missing_xmltodict.yml
+++ b/tests/integration/targets/cics_cmci_missing_xmltodict_library/playbooks/cmci_missing_xmltodict.yml
@@ -30,6 +30,3 @@
         that:
           - result.failed is false
           - '{{  result.msg[:58] == "Failed to import the required Python library (encoder) on " }}'
-          - '{{  result.msg[-232:] == "Please read the module documentation and install it in the appropriate location.
-                  If the required library is installed, but Ansible is using the wrong Python interpreter, please
-                  consult the documentation on ansible_python_interpreter" }}'

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -1,0 +1,6 @@
+docs/make.bat line-endings!skip # Windows batch file requires windows line endings
+plugins/modules/cmci_get.py validate-modules:missing-gplv3-license # Licence is Apache-2.0
+plugins/modules/cmci_action.py validate-modules:missing-gplv3-license # Licence is Apache-2.0
+plugins/modules/cmci_create.py validate-modules:missing-gplv3-license # Licence is Apache-2.0
+plugins/modules/cmci_delete.py validate-modules:missing-gplv3-license # Licence is Apache-2.0
+plugins/modules/cmci_update.py validate-modules:missing-gplv3-license # Licence is Apache-2.0


### PR DESCRIPTION
Though there's no automated way of doing that.  I did have to add some fixes to integration tests that didn't run successfully with Python 2.7, which I don't think was an issue with Ansible 2.9, but they hadn't been failing for me before, so maybe I only recently pulled those tests that I've had to change here.