### PR TITLE
Sanitise fields

### DIFF
--- a/tests/unit/helpers/cmci_helper.py
+++ b/tests/unit/helpers/cmci_helper.py
@@ -13,13 +13,7 @@ from requests import PreparedRequest
 from typing import List
 from sys import version_info
 import urllib
-
-try:
-    import requests
-except ImportError:
-    requests = None
-
-
+import requests
 import json
 import pytest
 import xmltodict


### PR DESCRIPTION
 - Improve sanitisation of parameter and criteria in queries
    - Escape any single quotes in filter values
    - Filter key and parameter name must be alphanumeric (100 character limit)
    - Parameter value cannot contain brackets ()
 - Add validation for CMCI Resource type (alphanumeric only)
 - New unit tests to cover additional sanitisation measures