### PR TITLE
CMCI Feedback Support

### DIFF
--- a/plugins/modules/cmci_action.py
+++ b/plugins/modules/cmci_action.py
@@ -244,6 +244,239 @@ request:
       description: The URL used for the request.
       returned: success
       type: str
+feedback:
+    description: Diagnostic data from FEEDBACK records associated with the request
+    returned: cmci error
+    type: list
+    elements: dict
+    contains:
+        action:
+            description: The name of the action that has failed.
+            returned: cmci error
+            type: str
+        attribute1:
+            description: The name of one of up to six attributes associated with the error.
+            returned: cmci error
+            type: str
+        attribute2:
+            description: The name of one of up to six attributes associated with the error.
+            returned: cmci error
+            type: str
+        attribute3:
+            description: The name of one of up to six attributes associated with the error.
+            returned: cmci error
+            type: str
+        attribute4:
+            description: The name of one of up to six attributes associated with the error.
+            returned: cmci error
+            type: str
+        attribute5:
+            description: The name of one of up to six attributes associated with the error.
+            returned: cmci error
+            type: str
+        attribute6:
+            description: The name of one of up to six attributes associated with the error.
+            returned: cmci error
+            type: str
+        eibfn:
+            description: The function code associated with the request.
+            returned: cmci error
+            type: str
+        eibfn_alt:
+            description: The name of the function associated with the request.
+            returned: cmci error
+            type: str
+        errorcode:
+            description: The CICSPlex® SM error code associated with the resource.
+            returned: cmci error
+            type: str
+        eyu_cicsname:
+            description: The name of the CICS region or CICSplex associated with the error.
+            returned: cmci error
+            type: str
+        keydata:
+            description: A string of data that identifies the instance of a resource associated with the error.
+            returned: cmci error
+            type: str
+        resp:
+            description: The CICS RESP code or the CICSPlex SM API EYUDA response code as a numeric value.
+            returned: cmci error
+            type: str
+        resp2:
+            description: The CICS RESP2 code or the CICSPlex SM API EYUDA reason code as a numeric value.
+            returned: cmci error
+            type: str
+        resp_alt:
+            description: >
+                The text equivalent for the resp value. For example, the text equivalent of a resp value of 16 is INVREQ.
+            returned: cmci error
+            type: str
+        installerror:
+            description: >
+                Contains diagnostic data from a BINSTERR record associated with a CICS® management client interface PUT install request.
+            returned: cmci error
+            type: list
+            elements: dict
+            contains:
+                eibfn:
+                    description: The function code associated with the request.
+                    returned: cmci error
+                    type: str
+                eyu_cicsname:
+                    description: The name of the CICS region or CICSplex associated with the installation error.
+                    returned: cmci error
+                    type: str
+                cresp1:
+                    description: The CICS RESP code or the CICSPlex® SM API EYUDA response code as a numeric value.
+                    returned: cmci error
+                    type: str
+                cresp2:
+                    description: The CICS RESP2 code or the CICSPlex SM API EYUDA reason code as a numeric value.
+                    returned: cmci error
+                    type: str
+                errorcode:
+                    description: The CICSPlex SM error code associated with the resource.
+                    returned: cmci error
+                    type: str
+                ressname:
+                    description: The name of the resource associated with the error.
+                    returned: cmci error
+                    type: str
+                resver:
+                    description: The version number of the resource associated with the error.
+                    returned: cmci error
+                    type: str
+        inconsistentscope:
+            description: >
+                Contains diagnostic data from a BINCONSC record associated with a CICS® management client interface PUT request.
+            returned: cmci error
+            type: list
+            elements: dict
+            contains:
+                eibfn:
+                    description: The function code associated with the request.
+                    returned: cmci error
+                    type: str
+                eyu_cicsname:
+                    description: The name of the CICS region or CICSplex associated with the installation error.
+                    returned: cmci error
+                    type: str
+                erroroperation:
+                    description: A numeric value that identifies the operation being performed when the error occurred.
+                    returned: cmci error
+                    type: str
+                errorcode:
+                    description: The CICSPlex® SM error code associated with the resource.
+                    returned: cmci error
+                    type: str
+                targetassignment:
+                    description: The assignment for the target scope.
+                    returned: cmci error
+                    type: str
+                targetdescription:
+                    description: The resource description for the target scope.
+                    returned: cmci error
+                    type: str
+                relatedassignment:
+                    description: The resource assignment for the related scope.
+                    returned: cmci error
+                    type: str
+                relateddescription:
+                    description: The resource description for the related scope.
+                    returned: cmci error
+                    type: str
+                relatedscope:
+                    description: The name of the related scope.
+                    returned: cmci error
+                    type: str
+        inconsistentset:
+            description: >
+                Contains diagnostic data from a BINCONRS record associated with a CICS® management client interface PUT request.
+            returned: cmci error
+            type: list
+            elements: dict
+            contains:
+                candidatename:
+                    description: The name of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidateversion:
+                    description: The version number of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidategroup:
+                    description: The resource group of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidateassignment:
+                    description: The assignment of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidatedescription:
+                    description: The description of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidateusage:
+                    description: The assignment usage of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidatesystemgroup:
+                    description: The system group of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidatetype:
+                    description: The system type of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidateoverride:
+                    description: The assignment override of the candidate resource.
+                    returned: cmci error
+                    type: str
+                eyu_cicsname:
+                    description: The name of the CICS region associated with the installation error.
+                    returned: cmci error
+                    type: str
+                erroroperation:
+                    description: >
+                        A numeric value that identifies that the operation being performed when the error occurred
+                    returned: cmci error
+                    type: str
+                existingname:
+                    description: The name of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingversion:
+                    description: The version number of the existing resource.
+                    returned: cmci error
+                    type: str
+                existinggroup:
+                    description: The resource group of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingassignment:
+                    description: The assignment of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingdescription:
+                    description: The description of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingusage:
+                    description: The assignment usage of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingsystemgroup:
+                    description: The system group of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingtype:
+                    description: The system type of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingoverride:
+                    description: The assignment override of the existing resource.
+                    returned: cmci error
+                    type: str
 """
 
 

--- a/plugins/modules/cmci_create.py
+++ b/plugins/modules/cmci_create.py
@@ -214,6 +214,239 @@ request:
       description: The URL used for the request.
       returned: success
       type: str
+feedback:
+    description: Diagnostic data from FEEDBACK records associated with the request
+    returned: cmci error
+    type: list
+    elements: dict
+    contains:
+        action:
+            description: The name of the action that has failed.
+            returned: cmci error
+            type: str
+        attribute1:
+            description: The name of one of up to six attributes associated with the error.
+            returned: cmci error
+            type: str
+        attribute2:
+            description: The name of one of up to six attributes associated with the error.
+            returned: cmci error
+            type: str
+        attribute3:
+            description: The name of one of up to six attributes associated with the error.
+            returned: cmci error
+            type: str
+        attribute4:
+            description: The name of one of up to six attributes associated with the error.
+            returned: cmci error
+            type: str
+        attribute5:
+            description: The name of one of up to six attributes associated with the error.
+            returned: cmci error
+            type: str
+        attribute6:
+            description: The name of one of up to six attributes associated with the error.
+            returned: cmci error
+            type: str
+        eibfn:
+            description: The function code associated with the request.
+            returned: cmci error
+            type: str
+        eibfn_alt:
+            description: The name of the function associated with the request.
+            returned: cmci error
+            type: str
+        errorcode:
+            description: The CICSPlex® SM error code associated with the resource.
+            returned: cmci error
+            type: str
+        eyu_cicsname:
+            description: The name of the CICS region or CICSplex associated with the error.
+            returned: cmci error
+            type: str
+        keydata:
+            description: A string of data that identifies the instance of a resource associated with the error.
+            returned: cmci error
+            type: str
+        resp:
+            description: The CICS RESP code or the CICSPlex SM API EYUDA response code as a numeric value.
+            returned: cmci error
+            type: str
+        resp2:
+            description: The CICS RESP2 code or the CICSPlex SM API EYUDA reason code as a numeric value.
+            returned: cmci error
+            type: str
+        resp_alt:
+            description: >
+                The text equivalent for the resp value. For example, the text equivalent of a resp value of 16 is INVREQ.
+            returned: cmci error
+            type: str
+        installerror:
+            description: >
+                Contains diagnostic data from a BINSTERR record associated with a CICS® management client interface PUT install request.
+            returned: cmci error
+            type: list
+            elements: dict
+            contains:
+                eibfn:
+                    description: The function code associated with the request.
+                    returned: cmci error
+                    type: str
+                eyu_cicsname:
+                    description: The name of the CICS region or CICSplex associated with the installation error.
+                    returned: cmci error
+                    type: str
+                cresp1:
+                    description: The CICS RESP code or the CICSPlex® SM API EYUDA response code as a numeric value.
+                    returned: cmci error
+                    type: str
+                cresp2:
+                    description: The CICS RESP2 code or the CICSPlex SM API EYUDA reason code as a numeric value.
+                    returned: cmci error
+                    type: str
+                errorcode:
+                    description: The CICSPlex SM error code associated with the resource.
+                    returned: cmci error
+                    type: str
+                ressname:
+                    description: The name of the resource associated with the error.
+                    returned: cmci error
+                    type: str
+                resver:
+                    description: The version number of the resource associated with the error.
+                    returned: cmci error
+                    type: str
+        inconsistentscope:
+            description: >
+                Contains diagnostic data from a BINCONSC record associated with a CICS® management client interface PUT request.
+            returned: cmci error
+            type: list
+            elements: dict
+            contains:
+                eibfn:
+                    description: The function code associated with the request.
+                    returned: cmci error
+                    type: str
+                eyu_cicsname:
+                    description: The name of the CICS region or CICSplex associated with the installation error.
+                    returned: cmci error
+                    type: str
+                erroroperation:
+                    description: A numeric value that identifies the operation being performed when the error occurred.
+                    returned: cmci error
+                    type: str
+                errorcode:
+                    description: The CICSPlex® SM error code associated with the resource.
+                    returned: cmci error
+                    type: str
+                targetassignment:
+                    description: The assignment for the target scope.
+                    returned: cmci error
+                    type: str
+                targetdescription:
+                    description: The resource description for the target scope.
+                    returned: cmci error
+                    type: str
+                relatedassignment:
+                    description: The resource assignment for the related scope.
+                    returned: cmci error
+                    type: str
+                relateddescription:
+                    description: The resource description for the related scope.
+                    returned: cmci error
+                    type: str
+                relatedscope:
+                    description: The name of the related scope.
+                    returned: cmci error
+                    type: str
+        inconsistentset:
+            description: >
+                Contains diagnostic data from a BINCONRS record associated with a CICS® management client interface PUT request.
+            returned: cmci error
+            type: list
+            elements: dict
+            contains:
+                candidatename:
+                    description: The name of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidateversion:
+                    description: The version number of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidategroup:
+                    description: The resource group of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidateassignment:
+                    description: The assignment of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidatedescription:
+                    description: The description of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidateusage:
+                    description: The assignment usage of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidatesystemgroup:
+                    description: The system group of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidatetype:
+                    description: The system type of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidateoverride:
+                    description: The assignment override of the candidate resource.
+                    returned: cmci error
+                    type: str
+                eyu_cicsname:
+                    description: The name of the CICS region associated with the installation error.
+                    returned: cmci error
+                    type: str
+                erroroperation:
+                    description: >
+                        A numeric value that identifies that the operation being performed when the error occurred
+                    returned: cmci error
+                    type: str
+                existingname:
+                    description: The name of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingversion:
+                    description: The version number of the existing resource.
+                    returned: cmci error
+                    type: str
+                existinggroup:
+                    description: The resource group of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingassignment:
+                    description: The assignment of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingdescription:
+                    description: The description of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingusage:
+                    description: The assignment usage of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingsystemgroup:
+                    description: The system group of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingtype:
+                    description: The system type of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingoverride:
+                    description: The assignment override of the existing resource.
+                    returned: cmci error
+                    type: str
 """
 
 

--- a/plugins/modules/cmci_delete.py
+++ b/plugins/modules/cmci_delete.py
@@ -204,6 +204,239 @@ request:
       description: The URL used for the request.
       returned: success
       type: str
+feedback:
+    description: Diagnostic data from FEEDBACK records associated with the request
+    returned: cmci error
+    type: list
+    elements: dict
+    contains:
+        action:
+            description: The name of the action that has failed.
+            returned: cmci error
+            type: str
+        attribute1:
+            description: The name of one of up to six attributes associated with the error.
+            returned: cmci error
+            type: str
+        attribute2:
+            description: The name of one of up to six attributes associated with the error.
+            returned: cmci error
+            type: str
+        attribute3:
+            description: The name of one of up to six attributes associated with the error.
+            returned: cmci error
+            type: str
+        attribute4:
+            description: The name of one of up to six attributes associated with the error.
+            returned: cmci error
+            type: str
+        attribute5:
+            description: The name of one of up to six attributes associated with the error.
+            returned: cmci error
+            type: str
+        attribute6:
+            description: The name of one of up to six attributes associated with the error.
+            returned: cmci error
+            type: str
+        eibfn:
+            description: The function code associated with the request.
+            returned: cmci error
+            type: str
+        eibfn_alt:
+            description: The name of the function associated with the request.
+            returned: cmci error
+            type: str
+        errorcode:
+            description: The CICSPlex® SM error code associated with the resource.
+            returned: cmci error
+            type: str
+        eyu_cicsname:
+            description: The name of the CICS region or CICSplex associated with the error.
+            returned: cmci error
+            type: str
+        keydata:
+            description: A string of data that identifies the instance of a resource associated with the error.
+            returned: cmci error
+            type: str
+        resp:
+            description: The CICS RESP code or the CICSPlex SM API EYUDA response code as a numeric value.
+            returned: cmci error
+            type: str
+        resp2:
+            description: The CICS RESP2 code or the CICSPlex SM API EYUDA reason code as a numeric value.
+            returned: cmci error
+            type: str
+        resp_alt:
+            description: >
+                The text equivalent for the resp value. For example, the text equivalent of a resp value of 16 is INVREQ.
+            returned: cmci error
+            type: str
+        installerror:
+            description: >
+                Contains diagnostic data from a BINSTERR record associated with a CICS® management client interface PUT install request.
+            returned: cmci error
+            type: list
+            elements: dict
+            contains:
+                eibfn:
+                    description: The function code associated with the request.
+                    returned: cmci error
+                    type: str
+                eyu_cicsname:
+                    description: The name of the CICS region or CICSplex associated with the installation error.
+                    returned: cmci error
+                    type: str
+                cresp1:
+                    description: The CICS RESP code or the CICSPlex® SM API EYUDA response code as a numeric value.
+                    returned: cmci error
+                    type: str
+                cresp2:
+                    description: The CICS RESP2 code or the CICSPlex SM API EYUDA reason code as a numeric value.
+                    returned: cmci error
+                    type: str
+                errorcode:
+                    description: The CICSPlex SM error code associated with the resource.
+                    returned: cmci error
+                    type: str
+                ressname:
+                    description: The name of the resource associated with the error.
+                    returned: cmci error
+                    type: str
+                resver:
+                    description: The version number of the resource associated with the error.
+                    returned: cmci error
+                    type: str
+        inconsistentscope:
+            description: >
+                Contains diagnostic data from a BINCONSC record associated with a CICS® management client interface PUT request.
+            returned: cmci error
+            type: list
+            elements: dict
+            contains:
+                eibfn:
+                    description: The function code associated with the request.
+                    returned: cmci error
+                    type: str
+                eyu_cicsname:
+                    description: The name of the CICS region or CICSplex associated with the installation error.
+                    returned: cmci error
+                    type: str
+                erroroperation:
+                    description: A numeric value that identifies the operation being performed when the error occurred.
+                    returned: cmci error
+                    type: str
+                errorcode:
+                    description: The CICSPlex® SM error code associated with the resource.
+                    returned: cmci error
+                    type: str
+                targetassignment:
+                    description: The assignment for the target scope.
+                    returned: cmci error
+                    type: str
+                targetdescription:
+                    description: The resource description for the target scope.
+                    returned: cmci error
+                    type: str
+                relatedassignment:
+                    description: The resource assignment for the related scope.
+                    returned: cmci error
+                    type: str
+                relateddescription:
+                    description: The resource description for the related scope.
+                    returned: cmci error
+                    type: str
+                relatedscope:
+                    description: The name of the related scope.
+                    returned: cmci error
+                    type: str
+        inconsistentset:
+            description: >
+                Contains diagnostic data from a BINCONRS record associated with a CICS® management client interface PUT request.
+            returned: cmci error
+            type: list
+            elements: dict
+            contains:
+                candidatename:
+                    description: The name of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidateversion:
+                    description: The version number of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidategroup:
+                    description: The resource group of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidateassignment:
+                    description: The assignment of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidatedescription:
+                    description: The description of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidateusage:
+                    description: The assignment usage of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidatesystemgroup:
+                    description: The system group of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidatetype:
+                    description: The system type of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidateoverride:
+                    description: The assignment override of the candidate resource.
+                    returned: cmci error
+                    type: str
+                eyu_cicsname:
+                    description: The name of the CICS region associated with the installation error.
+                    returned: cmci error
+                    type: str
+                erroroperation:
+                    description: >
+                        A numeric value that identifies that the operation being performed when the error occurred
+                    returned: cmci error
+                    type: str
+                existingname:
+                    description: The name of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingversion:
+                    description: The version number of the existing resource.
+                    returned: cmci error
+                    type: str
+                existinggroup:
+                    description: The resource group of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingassignment:
+                    description: The assignment of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingdescription:
+                    description: The description of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingusage:
+                    description: The assignment usage of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingsystemgroup:
+                    description: The system group of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingtype:
+                    description: The system type of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingoverride:
+                    description: The assignment override of the existing resource.
+                    returned: cmci error
+                    type: str
 """
 
 

--- a/plugins/modules/cmci_get.py
+++ b/plugins/modules/cmci_get.py
@@ -253,6 +253,239 @@ request:
       description: The URL used for the request.
       returned: success
       type: str
+feedback:
+    description: Diagnostic data from FEEDBACK records associated with the request
+    returned: cmci error
+    type: list
+    elements: dict
+    contains:
+        action:
+            description: The name of the action that has failed.
+            returned: cmci error
+            type: str
+        attribute1:
+            description: The name of one of up to six attributes associated with the error.
+            returned: cmci error
+            type: str
+        attribute2:
+            description: The name of one of up to six attributes associated with the error.
+            returned: cmci error
+            type: str
+        attribute3:
+            description: The name of one of up to six attributes associated with the error.
+            returned: cmci error
+            type: str
+        attribute4:
+            description: The name of one of up to six attributes associated with the error.
+            returned: cmci error
+            type: str
+        attribute5:
+            description: The name of one of up to six attributes associated with the error.
+            returned: cmci error
+            type: str
+        attribute6:
+            description: The name of one of up to six attributes associated with the error.
+            returned: cmci error
+            type: str
+        eibfn:
+            description: The function code associated with the request.
+            returned: cmci error
+            type: str
+        eibfn_alt:
+            description: The name of the function associated with the request.
+            returned: cmci error
+            type: str
+        errorcode:
+            description: The CICSPlex® SM error code associated with the resource.
+            returned: cmci error
+            type: str
+        eyu_cicsname:
+            description: The name of the CICS region or CICSplex associated with the error.
+            returned: cmci error
+            type: str
+        keydata:
+            description: A string of data that identifies the instance of a resource associated with the error.
+            returned: cmci error
+            type: str
+        resp:
+            description: The CICS RESP code or the CICSPlex SM API EYUDA response code as a numeric value.
+            returned: cmci error
+            type: str
+        resp2:
+            description: The CICS RESP2 code or the CICSPlex SM API EYUDA reason code as a numeric value.
+            returned: cmci error
+            type: str
+        resp_alt:
+            description: >
+                The text equivalent for the resp value. For example, the text equivalent of a resp value of 16 is INVREQ.
+            returned: cmci error
+            type: str
+        installerror:
+            description: >
+                Contains diagnostic data from a BINSTERR record associated with a CICS® management client interface PUT install request.
+            returned: cmci error
+            type: list
+            elements: dict
+            contains:
+                eibfn:
+                    description: The function code associated with the request.
+                    returned: cmci error
+                    type: str
+                eyu_cicsname:
+                    description: The name of the CICS region or CICSplex associated with the installation error.
+                    returned: cmci error
+                    type: str
+                cresp1:
+                    description: The CICS RESP code or the CICSPlex® SM API EYUDA response code as a numeric value.
+                    returned: cmci error
+                    type: str
+                cresp2:
+                    description: The CICS RESP2 code or the CICSPlex SM API EYUDA reason code as a numeric value.
+                    returned: cmci error
+                    type: str
+                errorcode:
+                    description: The CICSPlex SM error code associated with the resource.
+                    returned: cmci error
+                    type: str
+                ressname:
+                    description: The name of the resource associated with the error.
+                    returned: cmci error
+                    type: str
+                resver:
+                    description: The version number of the resource associated with the error.
+                    returned: cmci error
+                    type: str
+        inconsistentscope:
+            description: >
+                Contains diagnostic data from a BINCONSC record associated with a CICS® management client interface PUT request.
+            returned: cmci error
+            type: list
+            elements: dict
+            contains:
+                eibfn:
+                    description: The function code associated with the request.
+                    returned: cmci error
+                    type: str
+                eyu_cicsname:
+                    description: The name of the CICS region or CICSplex associated with the installation error.
+                    returned: cmci error
+                    type: str
+                erroroperation:
+                    description: A numeric value that identifies the operation being performed when the error occurred.
+                    returned: cmci error
+                    type: str
+                errorcode:
+                    description: The CICSPlex® SM error code associated with the resource.
+                    returned: cmci error
+                    type: str
+                targetassignment:
+                    description: The assignment for the target scope.
+                    returned: cmci error
+                    type: str
+                targetdescription:
+                    description: The resource description for the target scope.
+                    returned: cmci error
+                    type: str
+                relatedassignment:
+                    description: The resource assignment for the related scope.
+                    returned: cmci error
+                    type: str
+                relateddescription:
+                    description: The resource description for the related scope.
+                    returned: cmci error
+                    type: str
+                relatedscope:
+                    description: The name of the related scope.
+                    returned: cmci error
+                    type: str
+        inconsistentset:
+            description: >
+                Contains diagnostic data from a BINCONRS record associated with a CICS® management client interface PUT request.
+            returned: cmci error
+            type: list
+            elements: dict
+            contains:
+                candidatename:
+                    description: The name of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidateversion:
+                    description: The version number of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidategroup:
+                    description: The resource group of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidateassignment:
+                    description: The assignment of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidatedescription:
+                    description: The description of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidateusage:
+                    description: The assignment usage of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidatesystemgroup:
+                    description: The system group of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidatetype:
+                    description: The system type of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidateoverride:
+                    description: The assignment override of the candidate resource.
+                    returned: cmci error
+                    type: str
+                eyu_cicsname:
+                    description: The name of the CICS region associated with the installation error.
+                    returned: cmci error
+                    type: str
+                erroroperation:
+                    description: >
+                        A numeric value that identifies that the operation being performed when the error occurred
+                    returned: cmci error
+                    type: str
+                existingname:
+                    description: The name of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingversion:
+                    description: The version number of the existing resource.
+                    returned: cmci error
+                    type: str
+                existinggroup:
+                    description: The resource group of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingassignment:
+                    description: The assignment of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingdescription:
+                    description: The description of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingusage:
+                    description: The assignment usage of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingsystemgroup:
+                    description: The system group of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingtype:
+                    description: The system type of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingoverride:
+                    description: The assignment override of the existing resource.
+                    returned: cmci error
+                    type: str
 """
 
 from ansible_collections.ibm.ibm_zos_cics.plugins.module_utils.cmci import (

--- a/plugins/modules/cmci_update.py
+++ b/plugins/modules/cmci_update.py
@@ -219,6 +219,239 @@ request:
       description: The URL used for the request.
       returned: success
       type: str
+feedback:
+    description: Diagnostic data from FEEDBACK records associated with the request
+    returned: cmci error
+    type: list
+    elements: dict
+    contains:
+        action:
+            description: The name of the action that has failed.
+            returned: cmci error
+            type: str
+        attribute1:
+            description: The name of one of up to six attributes associated with the error.
+            returned: cmci error
+            type: str
+        attribute2:
+            description: The name of one of up to six attributes associated with the error.
+            returned: cmci error
+            type: str
+        attribute3:
+            description: The name of one of up to six attributes associated with the error.
+            returned: cmci error
+            type: str
+        attribute4:
+            description: The name of one of up to six attributes associated with the error.
+            returned: cmci error
+            type: str
+        attribute5:
+            description: The name of one of up to six attributes associated with the error.
+            returned: cmci error
+            type: str
+        attribute6:
+            description: The name of one of up to six attributes associated with the error.
+            returned: cmci error
+            type: str
+        eibfn:
+            description: The function code associated with the request.
+            returned: cmci error
+            type: str
+        eibfn_alt:
+            description: The name of the function associated with the request.
+            returned: cmci error
+            type: str
+        errorcode:
+            description: The CICSPlex® SM error code associated with the resource.
+            returned: cmci error
+            type: str
+        eyu_cicsname:
+            description: The name of the CICS region or CICSplex associated with the error.
+            returned: cmci error
+            type: str
+        keydata:
+            description: A string of data that identifies the instance of a resource associated with the error.
+            returned: cmci error
+            type: str
+        resp:
+            description: The CICS RESP code or the CICSPlex SM API EYUDA response code as a numeric value.
+            returned: cmci error
+            type: str
+        resp2:
+            description: The CICS RESP2 code or the CICSPlex SM API EYUDA reason code as a numeric value.
+            returned: cmci error
+            type: str
+        resp_alt:
+            description: >
+                The text equivalent for the resp value. For example, the text equivalent of a resp value of 16 is INVREQ.
+            returned: cmci error
+            type: str
+        installerror:
+            description: >
+                Contains diagnostic data from a BINSTERR record associated with a CICS® management client interface PUT install request.
+            returned: cmci error
+            type: list
+            elements: dict
+            contains:
+                eibfn:
+                    description: The function code associated with the request.
+                    returned: cmci error
+                    type: str
+                eyu_cicsname:
+                    description: The name of the CICS region or CICSplex associated with the installation error.
+                    returned: cmci error
+                    type: str
+                cresp1:
+                    description: The CICS RESP code or the CICSPlex® SM API EYUDA response code as a numeric value.
+                    returned: cmci error
+                    type: str
+                cresp2:
+                    description: The CICS RESP2 code or the CICSPlex SM API EYUDA reason code as a numeric value.
+                    returned: cmci error
+                    type: str
+                errorcode:
+                    description: The CICSPlex SM error code associated with the resource.
+                    returned: cmci error
+                    type: str
+                ressname:
+                    description: The name of the resource associated with the error.
+                    returned: cmci error
+                    type: str
+                resver:
+                    description: The version number of the resource associated with the error.
+                    returned: cmci error
+                    type: str
+        inconsistentscope:
+            description: >
+                Contains diagnostic data from a BINCONSC record associated with a CICS® management client interface PUT request.
+            returned: cmci error
+            type: list
+            elements: dict
+            contains:
+                eibfn:
+                    description: The function code associated with the request.
+                    returned: cmci error
+                    type: str
+                eyu_cicsname:
+                    description: The name of the CICS region or CICSplex associated with the installation error.
+                    returned: cmci error
+                    type: str
+                erroroperation:
+                    description: A numeric value that identifies the operation being performed when the error occurred.
+                    returned: cmci error
+                    type: str
+                errorcode:
+                    description: The CICSPlex® SM error code associated with the resource.
+                    returned: cmci error
+                    type: str
+                targetassignment:
+                    description: The assignment for the target scope.
+                    returned: cmci error
+                    type: str
+                targetdescription:
+                    description: The resource description for the target scope.
+                    returned: cmci error
+                    type: str
+                relatedassignment:
+                    description: The resource assignment for the related scope.
+                    returned: cmci error
+                    type: str
+                relateddescription:
+                    description: The resource description for the related scope.
+                    returned: cmci error
+                    type: str
+                relatedscope:
+                    description: The name of the related scope.
+                    returned: cmci error
+                    type: str
+        inconsistentset:
+            description: >
+                Contains diagnostic data from a BINCONRS record associated with a CICS® management client interface PUT request.
+            returned: cmci error
+            type: list
+            elements: dict
+            contains:
+                candidatename:
+                    description: The name of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidateversion:
+                    description: The version number of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidategroup:
+                    description: The resource group of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidateassignment:
+                    description: The assignment of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidatedescription:
+                    description: The description of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidateusage:
+                    description: The assignment usage of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidatesystemgroup:
+                    description: The system group of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidatetype:
+                    description: The system type of the candidate resource.
+                    returned: cmci error
+                    type: str
+                candidateoverride:
+                    description: The assignment override of the candidate resource.
+                    returned: cmci error
+                    type: str
+                eyu_cicsname:
+                    description: The name of the CICS region associated with the installation error.
+                    returned: cmci error
+                    type: str
+                erroroperation:
+                    description: >
+                        A numeric value that identifies that the operation being performed when the error occurred
+                    returned: cmci error
+                    type: str
+                existingname:
+                    description: The name of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingversion:
+                    description: The version number of the existing resource.
+                    returned: cmci error
+                    type: str
+                existinggroup:
+                    description: The resource group of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingassignment:
+                    description: The assignment of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingdescription:
+                    description: The description of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingusage:
+                    description: The assignment usage of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingsystemgroup:
+                    description: The system group of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingtype:
+                    description: The system type of the existing resource.
+                    returned: cmci error
+                    type: str
+                existingoverride:
+                    description: The assignment override of the existing resource.
+                    returned: cmci error
+                    type: str
 """
 
 

--- a/tests/integration/targets/cics_cmci/cmci-variables.yml.template
+++ b/tests/integration/targets/cics_cmci/cmci-variables.yml.template
@@ -2,8 +2,9 @@
 # Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)
 ---
 cmci_host: winmvs28.hursley.ibm.com
-cmci_port: 28951
+cmci_port: 28953
+cmci_secure_port: 28951
 cmci_user: __user__
 cmci_password: __password__
-context: CICSEX56
-scope: IYCWEMW2
+cmci_context: CICSEX56
+cmci_scope: IYCWEMW2

--- a/tests/integration/targets/cics_cmci/playbooks/cics_cmci_http.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cics_cmci_http.yml
@@ -1,7 +1,7 @@
 # (c) Copyright IBM Corp. 2020,2021
 # Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)
 ---
-- name:  CMCI Integration Test
+- name:  CMCI HTTP Integration Test
   collections:
    - ibm.ibm_zos_cics
   hosts: 'localhost'
@@ -9,16 +9,15 @@
   vars:
     csdgroup: 'HTTPTEST'
     program: 'HTTPTEST'
-    http_port: 28953
     http_scope: IYCWEMW1
 
   module_defaults:
     ibm.ibm_zos_cics.cmci_get:
       cmci_host: '{{ cmci_host }}'
-      cmci_port: '{{ http_port }}'
+      cmci_port: '{{ cmci_port }}'
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
-      context: '{{ context }}'
+      context: '{{ cmci_context }}'
       scope: '{{ http_scope }}'
       insecure: true
       scheme: 'http'
@@ -26,10 +25,10 @@
 
     ibm.ibm_zos_cics.cmci_update:
       cmci_host: '{{ cmci_host }}'
-      cmci_port: '{{ http_port }}'
+      cmci_port: '{{ cmci_port }}'
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
-      context: '{{ context }}'
+      context: '{{ cmci_context }}'
       scope: '{{ http_scope }}'
       insecure: true
       scheme: 'http'
@@ -37,10 +36,10 @@
 
     ibm.ibm_zos_cics.cmci_delete:
       cmci_host: '{{ cmci_host }}'
-      cmci_port: '{{ http_port }}'
+      cmci_port: '{{ cmci_port }}'
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
-      context: '{{ context }}'
+      context: '{{ cmci_context }}'
       scope: '{{ http_scope }}'
       insecure: true
       scheme: 'http'
@@ -48,10 +47,10 @@
 
     ibm.ibm_zos_cics.cmci_action:
       cmci_host: '{{ cmci_host }}'
-      cmci_port: '{{ http_port }}'
+      cmci_port: '{{ cmci_port }}'
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
-      context: '{{ context }}'
+      context: '{{ cmci_context }}'
       scope: '{{ http_scope }}'
       insecure: true
       scheme: 'http'
@@ -59,10 +58,10 @@
 
     ibm.ibm_zos_cics.cmci_create:
       cmci_host: '{{ cmci_host }}'
-      cmci_port: '{{ http_port }}'
+      cmci_port: '{{ cmci_port }}'
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
-      context: '{{ context }}'
+      context: '{{ cmci_context }}'
       scope: '{{ http_scope }}'
       insecure: true
       scheme: 'http'

--- a/tests/integration/targets/cics_cmci/playbooks/cics_cmci_https.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cics_cmci_https.yml
@@ -1,7 +1,7 @@
 # (c) Copyright IBM Corp. 2021
 # Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)
 ---
-- name:  CMCI Integration Test
+- name:  CMCI HTTPS Integration Test
   collections:
    - ibm.ibm_zos_cics
   hosts: 'localhost'
@@ -14,50 +14,50 @@
     # No support for supplying custom module_defaults groups yet :(
     ibm.ibm_zos_cics.cmci_get:
       cmci_host: '{{ cmci_host }}'
-      cmci_port: '{{ cmci_port }}'
+      cmci_port: '{{ cmci_secure_port }}'
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
-      context: '{{ context }}'
-      scope: '{{ scope }}'
+      context: '{{ cmci_context }}'
+      scope: '{{ cmci_scope }}'
       insecure: true
 
     ibm.ibm_zos_cics.cmci_update:
       cmci_host: '{{ cmci_host }}'
-      cmci_port: '{{ cmci_port }}'
+      cmci_port: '{{ cmci_secure_port }}'
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
-      context: '{{ context }}'
-      scope: '{{ scope }}'
+      context: '{{ cmci_context }}'
+      scope: '{{ cmci_scope }}'
       insecure: true
 
 
     ibm.ibm_zos_cics.cmci_delete:
       cmci_host: '{{ cmci_host }}'
-      cmci_port: '{{ cmci_port }}'
+      cmci_port: '{{ cmci_secure_port }}'
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
-      context: '{{ context }}'
-      scope: '{{ scope }}'
+      context: '{{ cmci_context }}'
+      scope: '{{ cmci_scope }}'
       insecure: true
 
 
     ibm.ibm_zos_cics.cmci_action:
       cmci_host: '{{ cmci_host }}'
-      cmci_port: '{{ cmci_port }}'
+      cmci_port: '{{ cmci_secure_port }}'
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
-      context: '{{ context }}'
-      scope: '{{ scope }}'
+      context: '{{ cmci_context }}'
+      scope: '{{ cmci_scope }}'
       insecure: true
 
 
     ibm.ibm_zos_cics.cmci_create:
       cmci_host: '{{ cmci_host }}'
-      cmci_port: '{{ cmci_port }}'
+      cmci_port: '{{ cmci_secure_port }}'
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
-      context: '{{ context }}'
-      scope: '{{ scope }}'
+      context: '{{ cmci_context }}'
+      scope: '{{ cmci_scope }}'
       insecure: true
 
   tasks:

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_bas_install_error.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_bas_install_error.yml
@@ -1,23 +1,26 @@
 # (c) Copyright IBM Corp. 2021
 # Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)
 ---
-- name:  CMCI BAS Install Integration Test
-  # Sets Up a full BAS resource assignment deployment. Checks to see where programs will be installed and then
-  # installs to two regions with a target scope and one related scope. Uninstalls and deletes everything created after
+- name:  CMCI BAS Install Error Integration Test
+  # Sets Up a full BAS resource assignment deployment. Checks to see where files will be installed and then
+  # installs to two regions with a target scope and one related scope. Then attempts to install again and checks an error
+  # occured with feedback and nested installerrors. Uninstalls and deletes everything created after
 
   collections:
    - ibm.ibm_zos_cics
   hosts: 'localhost'
   gather_facts: 'false'
   vars:
-    program: 'ANSIPROG'
+    res_def: 'ANSIFIL*'
+    file1: 'ANSIFIL1'
+    file2: 'ANSIFIL2'
     resource_description: 'ANSIDESC'
     resource_assignment: 'ANSIGMNT'
+    resource_assignment_type_target: 'CICSRemoteFile'
+    resource_assignment_type_related: 'CICSLocalFile'
     resource_group: 'ANSIRGRP'
     related_scope: 'IYCWEMW1'
-    region_one: 'IYCWEML1'
-    region_two: 'IYCWEMM1'
-    target_scope: 'ANSITARG'
+    target_scope: 'IYCWEML1'
     def_ver: '1'
 
 
@@ -86,16 +89,30 @@
       failed_when: >
         'cpsm_response' not in result or result.cpsm_response not in ['OK', 'NODATA']
 
-
-    - name: 'Delete program definition'
+    - name: 'Delete file1 definition'
       delegate_to: 'localhost'
       ibm.ibm_zos_cics.cmci_delete:
-        type: 'CICSDefinitionProgram'
+        type: 'CICSDefinitionFile'
         resources:
           complex_filter:
             and:
               - attribute: NAME
-                value: '{{ program }}'
+                value: '{{ file1 }}'
+              - attribute: DEFVER
+                value: '{{ def_ver }}'
+      register: result
+      failed_when: >
+        'cpsm_response' not in result or result.cpsm_response not in ['OK', 'NODATA']
+
+    - name: 'Delete file2 definition'
+      delegate_to: 'localhost'
+      ibm.ibm_zos_cics.cmci_delete:
+        type: 'CICSDefinitionFile'
+        resources:
+          complex_filter:
+            and:
+              - attribute: NAME
+                value: '{{ file2 }}'
               - attribute: DEFVER
                 value: '{{ def_ver }}'
       register: result
@@ -103,43 +120,48 @@
         'cpsm_response' not in result or result.cpsm_response not in ['OK', 'NODATA']
 
 
-    - name: 'Delete program in region one'
-      delegate_to: 'localhost'
-      ibm.ibm_zos_cics.cmci_delete:
-        type: 'CICSProgram'
-        scope: '{{ region_one }}'
-        resources:
-          filter:
-            program: '{{ program }}'
-      register: result
-      failed_when: >
-        'cpsm_response' not in result or result.cpsm_response not in ['OK', 'NODATA']
+    ###
+    # DISABLE AND DISCARD file1 and file2 in each region it may be installed
+    ###
+    - name: 'Check if file1 is installed in target scope'
+      include_role:
+        name: cmci_delete_if_exists
+      vars:
+        resource_type: '{{ resource_assignment_type_target }}'
+        context: '{{ cmci_context }}'
+        scope: '{{ target_scope }}'
+        attributes:
+          FILE: '{{ file1 }}'
 
-
-    - name: 'Delete program in region two'
-      delegate_to: 'localhost'
-      ibm.ibm_zos_cics.cmci_delete:
-        type: 'CICSProgram'
-        scope: '{{ region_two }}'
-        resources:
-          filter:
-            program: '{{ program }}'
-      register: result
-      failed_when: >
-        'cpsm_response' not in result or result.cpsm_response not in ['OK', 'NODATA']
-
-
-    - name: 'Delete program in related scope'
-      delegate_to: 'localhost'
-      ibm.ibm_zos_cics.cmci_delete:
-        type: 'CICSProgram'
+    - name: 'Check if file1 is installed in related scope'
+      include_role:
+        name: cmci_disable_discard_if_exists
+      vars:
+        resource_type: '{{ resource_assignment_type_related }}'
+        context: '{{ cmci_context }}'
         scope: '{{ related_scope }}'
-        resources:
-          filter:
-            program: '{{ program }}'
-      register: result
-      failed_when: >
-        'cpsm_response' not in result or result.cpsm_response not in ['OK', 'NODATA']
+        attributes:
+          FILE: '{{ file1 }}'
+
+    - name: 'Check if file2 is installed in target scope'
+      include_role:
+        name: cmci_delete_if_exists
+      vars:
+        resource_type: '{{ resource_assignment_type_target }}'
+        context: '{{ cmci_context }}'
+        scope: '{{ target_scope }}'
+        attributes:
+          FILE: '{{ file2 }}'
+
+    - name: 'Check if file2 is installed in related scope'
+      include_role:
+        name: cmci_disable_discard_if_exists
+      vars:
+        resource_type: '{{ resource_assignment_type_related }}'
+        context: '{{ cmci_context }}'
+        scope: '{{ related_scope }}'
+        attributes:
+          FILE: '{{ file2 }}'
 
 
     - name: 'Delete resource group'
@@ -166,37 +188,43 @@
         'cpsm_response' not in result or result.cpsm_response not in ['OK', 'NODATA']
 
 
-    - name: 'Delete system group target scope'
-      delegate_to: 'localhost'
-      ibm.ibm_zos_cics.cmci_delete:
-        type: 'CICSRegionGroup'
-        resources:
-          filter:
-            group: '{{ target_scope }}'
-      register: result
-      failed_when: >
-        'cpsm_response' not in result or result.cpsm_response not in ['OK', 'NODATA']
-
-
     ##################################################################################
     # Main Test
     ##################################################################################
-    - name: 'Create progdef'
+    - name: 'Create filedef1'
       delegate_to: 'localhost'
       ibm.ibm_zos_cics.cmci_create:
-        type: 'CICSDefinitionProgram'
+        type: 'CICSDefinitionFile'
         attributes:
-          name: '{{ program }}'
+          name: '{{ file1 }}'
           defver: '{{ def_ver }}'
       register: result
 
-    - name: assert progdef created
+    - name: assert filedef created
       assert:
         that:
           - result is changed
           - result.cpsm_response == 'OK'
           - result.record_count == 1
-          - result.records[0].name == program
+          - result.records[0].name == file1
+
+
+    - name: 'Create filedef2'
+      delegate_to: 'localhost'
+      ibm.ibm_zos_cics.cmci_create:
+        type: 'CICSDefinitionFile'
+        attributes:
+          name: '{{ file2 }}'
+          defver: '{{ def_ver }}'
+      register: result
+
+    - name: assert filedef created
+      assert:
+        that:
+          - result is changed
+          - result.cpsm_response == 'OK'
+          - result.record_count == 1
+          - result.records[0].name == file2
 
 
     - name: 'Create Resource Group'
@@ -216,82 +244,50 @@
           - result.records[0].resgroup == resource_group
 
 
-    - name: 'Add progdef to resource group'
+    - name: 'Add filedef1 to resource group'
       delegate_to: 'localhost'
       ibm.ibm_zos_cics.cmci_action:
-        type: 'CICSDefinitionProgram'
+        type: 'CICSDefinitionFile'
         action_name: 'ADDTOGRP'
         resources:
           filter:
-            NAME: '{{ program }}'
+            NAME: '{{ file1 }}'
             DEFVER: '{{ def_ver }}'
         action_parameters:
           - name: 'RESGROUP'
             value: '{{ resource_group }}'
       register: result
 
-    - name: assert progdef added to resource group
+    - name: assert filedef added to resource group
       assert:
         that:
           - result is changed
           - result.cpsm_response == 'OK'
           - result.record_count == 1
-          - result.records[0].name == program
+          - result.records[0].name == file1
 
 
-    - name: 'Create system group for target scope'
+    - name: 'Add filedef2 to resource group'
       delegate_to: 'localhost'
-      ibm.ibm_zos_cics.cmci_create:
-        type: 'CICSRegionGroup'
-        attributes:
-          group: '{{ target_scope }}'
+      ibm.ibm_zos_cics.cmci_action:
+        type: 'CICSDefinitionFile'
+        action_name: 'ADDTOGRP'
+        resources:
+          filter:
+            NAME: '{{ file2 }}'
+            DEFVER: '{{ def_ver }}'
+        action_parameters:
+          - name: 'RESGROUP'
+            value: '{{ resource_group }}'
       register: result
 
-    - name: assert create system group
+    - name: assert filedef added to resource group
       assert:
         that:
           - result is changed
           - result.cpsm_response == 'OK'
           - result.record_count == 1
-          - result.records[0].group == target_scope
-
-
-    - name: 'Add region one to target scope'
-      delegate_to: 'localhost'
-      ibm.ibm_zos_cics.cmci_create:
-        type: 'CICSSystemToSystemGroup'
-        attributes:
-          group: '{{ target_scope }}'
-          cicsname: '{{ region_one }}'
-      register: result
-
-    - name: assert region one added to system group
-      assert:
-        that:
-          - result is changed
-          - result.cpsm_response == 'OK'
-          - result.record_count == 1
-          - result.records[0].group == target_scope
-          - result.records[0].cicsname == region_one
-
-
-    - name: 'Add region two to target scope'
-      delegate_to: 'localhost'
-      ibm.ibm_zos_cics.cmci_create:
-        type: 'CICSSystemToSystemGroup'
-        attributes:
-          group: '{{ target_scope }}'
-          cicsname: '{{ region_two }}'
-      register: result
-
-    - name: assert region two added to system group
-      assert:
-        that:
-          - result is changed
-          - result.cpsm_response == 'OK'
-          - result.record_count == 1
-          - result.records[0].group == target_scope
-          - result.records[0].cicsname == region_two
+          - result.records[0].name == file2
 
 
     - name: 'Create Resource Description'
@@ -321,7 +317,7 @@
           rscope: '{{ related_scope }}'
           tscope: '{{ target_scope }}'
           resgroup: '{{ resource_group }}'
-          rdeftype: 'progdef'
+          rdeftype: 'filedef'
       register: result
 
     - name: assert create resource assignment
@@ -335,7 +331,7 @@
           - result.records[0].rscope == related_scope
           - result.records[0].tscope == target_scope
           - result.records[0].resgroup == resource_group
-          - result.records[0].rdeftype == 'PROGDEF'
+          - result.records[0].rdeftype == 'FILEDEF'
 
 
     - name: 'Add resource assignment to resource description'
@@ -378,110 +374,175 @@
           - result.record_count == 1
 
 
-    - name: 'Check program where program will be deployed by resource assignmnet'
+    - name: 'Check file where filedef will be deployed by resource assignmnet'
       delegate_to: 'localhost'
       ibm.ibm_zos_cics.cmci_get:
         type: 'CICSResourceByDescription'
         resources:
           filter:
             resdesc: '{{ resource_description }}'
-            resdef: '{{ program }}'
+            resdef: '{{ res_def }}'
           get_parameters:
             - name: 'RESDESC'
               value: '{{ resource_description }}'
       register: result
 
-    - name: assert where program will be installed
+    - name: assert where filedef will be installed
       assert:
         that:
           - result is not changed
           - result.cpsm_response == 'OK'
-          - result.record_count == 3
+          - result.record_count == 4
 
-          - result.records[0].resdef == program
-          - result.records[0].rdeftype == 'PROGDEF'
+          - result.records[0].resdef == file1
+          - result.records[0].rdeftype == 'FILEDEF'
           - result.records[0].resassgn == resource_assignment
           - result.records[0].resgroup == resource_group
           - result.records[0].rscope == related_scope
 
-          - result.records[1].resdef == program
-          - result.records[1].rdeftype == 'PROGDEF'
+          - result.records[1].resdef == file1
+          - result.records[1].rdeftype == 'FILEDEF'
           - result.records[1].resassgn == resource_assignment
           - result.records[1].resgroup == resource_group
-          - result.records[1].tscope == region_one
+          - result.records[1].tscope == target_scope
 
-          - result.records[2].resdef == program
-          - result.records[2].rdeftype == 'PROGDEF'
+          - result.records[2].resdef == file2
+          - result.records[2].rdeftype == 'FILEDEF'
           - result.records[2].resassgn == resource_assignment
           - result.records[2].resgroup == resource_group
-          - result.records[2].tscope == region_two
+          - result.records[2].rscope == related_scope
+
+          - result.records[3].resdef == file2
+          - result.records[3].rdeftype == 'FILEDEF'
+          - result.records[3].resassgn == resource_assignment
+          - result.records[3].resgroup == resource_group
+          - result.records[3].tscope == target_scope
 
 
-    - name: 'Check program was installed in region one'
+    - name: 'Check file1 was installed in target region'
       delegate_to: 'localhost'
       ibm.ibm_zos_cics.cmci_get:
-        type: 'CICSProgram'
-        scope: '{{ region_one }}'
+        type: 'CICSRemoteFile'
+        scope: '{{ target_scope }}'
         resources:
           filter:
-            program: '{{ program }}'
+            file: '{{ file1 }}'
       retries: 3
       until: result is not failed
       register: result
 
-    - name: assert program was installed in region one
+    - name: assert file1 was installed in target region
       assert:
         that:
           - result is not changed
           - result.cpsm_response == 'OK'
           - result.record_count == 1
-          - result.records[0].program == program
+          - result.records[0].remotename == file1
 
 
-    - name: 'Check program was installed in region two'
+    - name: 'Check file2 was installed in target region'
       delegate_to: 'localhost'
       ibm.ibm_zos_cics.cmci_get:
-        type: 'CICSProgram'
-        scope: '{{ region_two }}'
+        type: 'CICSRemoteFile'
+        scope: '{{ target_scope }}'
         resources:
           filter:
-            program: '{{ program }}'
+            file: '{{ file2 }}'
       retries: 3
       until: result is not failed
       register: result
 
-    - name: assert program was installed in region two
+    - name: assert file2 was installed in target scope
       assert:
         that:
           - result is not changed
           - result.cpsm_response == 'OK'
           - result.record_count == 1
-          - result.records[0].program == program
+          - result.records[0].remotename == file2
 
 
-    - name: 'Check program was installed in related scope'
+    - name: 'Check file1 was installed in related scope'
       delegate_to: 'localhost'
       ibm.ibm_zos_cics.cmci_get:
-        type: 'CICSProgram'
+        type: 'CICSLocalFile'
         scope: '{{ related_scope }}'
         resources:
           filter:
-            program: '{{ program }}'
+            file: '{{ file1 }}'
       retries: 3
       until: result is not failed
       register: result
 
-    - name: debug 2
-      debug:
-        msg: "{{ result }}"
-
-    - name: assert program was installed in related scope
+    - name: assert file1 was installed in related scope
       assert:
         that:
           - result is not changed
           - result.cpsm_response == 'OK'
           - result.record_count == 1
-          - result.records[0].program == program
+          - result.records[0].file == file1
+
+    - name: 'Check file2 was installed in related scope'
+      delegate_to: 'localhost'
+      ibm.ibm_zos_cics.cmci_get:
+        type: 'CICSLocalFile'
+        scope: '{{ related_scope }}'
+        resources:
+          filter:
+            file: '{{ file2 }}'
+      retries: 3
+      until: result is not failed
+      register: result
+
+    - name: assert file2 was installed in related scope
+      assert:
+        that:
+          - result is not changed
+          - result.cpsm_response == 'OK'
+          - result.record_count == 1
+          - result.records[0].file == file2
+
+    #####################################################
+    # Test correct feedback given on installation error #
+    #####################################################
+    - name: 'Install resource description again'
+      delegate_to: 'localhost'
+      ibm.ibm_zos_cics.cmci_action:
+        type: 'CICSResourceDescription'
+        action_name: 'INSTALL'
+        resources:
+          filter:
+            resdesc: '{{ resource_description }}'
+      register: result
+      failed_when: false
+
+    - name: assert feedback error is correct
+      assert:
+        that:
+          - result.cpsm_response == 'TABLEERROR'
+          - result.cpsm_reason == 'DATAERROR'
+          - result.record_count == 1
+
+          - result.feedback[0].installerror[0].resourcename == file1
+          - result.feedback[0].installerror[0].eyu_cicsname == related_scope
+          - result.feedback[0].installerror[0].resp == '16'
+          - result.feedback[0].installerror[0].resp2 == '500'
+          - result.feedback[0].installerror[0].resp_alt == 'INVREQ'
+          - result.feedback[0].installerror[0].eibfn == '3014'
+          - result.feedback[0].installerror[0].eibfn_alt == 'CREATE FILE'
+          - result.feedback[0].installerror[0].resourceversion == '1'
+
+          - result.feedback[0].installerror[1].resourcename == file2
+          - result.feedback[0].installerror[1].eyu_cicsname == related_scope
+          - result.feedback[0].installerror[1].resp == '16'
+          - result.feedback[0].installerror[1].resp2 == '500'
+          - result.feedback[0].installerror[1].resp_alt == 'INVREQ'
+          - result.feedback[0].installerror[1].eibfn == '3014'
+          - result.feedback[0].installerror[1].eibfn_alt == 'CREATE FILE'
+          - result.feedback[0].installerror[1].resourceversion == '1'
+
+          - result.feedback[1].action == 'INSTALL'
+          - result.feedback[1].attribute1 == 'RESDESC'
+          - result.feedback[1].errorcode == '29'
 
 
     ##################################################################################
@@ -505,19 +566,40 @@
           - result.success_count == 1
 
 
-    - name: 'Delete progdef'
+    - name: 'Delete filedef1'
       delegate_to: 'localhost'
       ibm.ibm_zos_cics.cmci_delete:
-        type: 'CICSDefinitionProgram'
+        type: 'CICSDefinitionFile'
         resources:
           filter:
-            name: '{{ program }}'
+            name: '{{ file1 }}'
           get_parameters:
             - name: 'RESGROUP'
               value: '{{ resource_group }}'
       register: result
 
-    - name: assert deleted progdef
+    - name: assert deleted filedef1
+      assert:
+        that:
+          - result is changed
+          - result.cpsm_response == 'OK'
+          - result.record_count == 1
+          - result.success_count == 1
+
+
+    - name: 'Delete filedef2'
+      delegate_to: 'localhost'
+      ibm.ibm_zos_cics.cmci_delete:
+        type: 'CICSDefinitionFile'
+        resources:
+          filter:
+            name: '{{ file2 }}'
+          get_parameters:
+            - name: 'RESGROUP'
+              value: '{{ resource_group }}'
+      register: result
+
+    - name: assert deleted filedef2
       assert:
         that:
           - result is changed
@@ -562,76 +644,42 @@
           - result.success_count == 1
 
 
-    - name: 'Delete system group target scope'
-      delegate_to: 'localhost'
-      ibm.ibm_zos_cics.cmci_delete:
-        type: 'CICSRegionGroup'
-        resources:
-          filter:
-            group: '{{ target_scope }}'
-      register: result
+    - name: 'Check if file1 is installed in target scope'
+      include_role:
+        name: cmci_delete_if_exists
+      vars:
+        resource_type: '{{ resource_assignment_type_target }}'
+        context: '{{ cmci_context }}'
+        scope: '{{ target_scope }}'
+        attributes:
+          FILE: '{{ file1 }}'
 
-    - name: assert deleted system group target scope
-      assert:
-        that:
-          - result is changed
-          - result.cpsm_response == 'OK'
-          - result.record_count == 1
-          - result.success_count == 1
-
-
-    - name: 'Delete program in region one'
-      delegate_to: 'localhost'
-      ibm.ibm_zos_cics.cmci_delete:
-        type: 'CICSProgram'
-        scope: '{{ region_one }}'
-        resources:
-          filter:
-            program: '{{ program }}'
-      register: result
-
-    - name: assert program deleted in region one
-      assert:
-        that:
-          - result is changed
-          - result.cpsm_response == 'OK'
-          - result.record_count == 1
-          - result.success_count == 1
-
-
-    - name: 'Delete program in region two'
-      delegate_to: 'localhost'
-      ibm.ibm_zos_cics.cmci_delete:
-        type: 'CICSProgram'
-        scope: '{{ region_two }}'
-        resources:
-          filter:
-            program: '{{ program }}'
-      register: result
-
-    - name: assert program deleted in region two
-      assert:
-        that:
-          - result is changed
-          - result.cpsm_response == 'OK'
-          - result.record_count == 1
-          - result.success_count == 1
-
-
-    - name: 'Delete program in related scope'
-      delegate_to: 'localhost'
-      ibm.ibm_zos_cics.cmci_delete:
-        type: 'CICSProgram'
+    - name: 'Check if file1 is installed in related scope'
+      include_role:
+        name: cmci_disable_discard_if_exists
+      vars:
+        resource_type: '{{ resource_assignment_type_related }}'
+        context: '{{ cmci_context }}'
         scope: '{{ related_scope }}'
-        resources:
-          filter:
-            program: '{{ program }}'
-      register: result
+        attributes:
+          FILE: '{{ file1 }}'
 
-    - name: assert program deleted in related scope
-      assert:
-        that:
-          - result is changed
-          - result.cpsm_response == 'OK'
-          - result.record_count == 1
-          - result.success_count == 1
+    - name: 'Check if file2 is installed in target scope'
+      include_role:
+        name: cmci_delete_if_exists
+      vars:
+        resource_type: '{{ resource_assignment_type_target }}'
+        context: '{{ cmci_context }}'
+        scope: '{{ target_scope }}'
+        attributes:
+          FILE: '{{ file2 }}'
+
+    - name: 'Check if file2 is installed in related scope'
+      include_role:
+        name: cmci_disable_discard_if_exists
+      vars:
+        resource_type: '{{ resource_assignment_type_related }}'
+        context: '{{ cmci_context }}'
+        scope: '{{ related_scope }}'
+        attributes:
+          FILE: '{{ file2 }}'

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_bas_link.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_bas_link.yml
@@ -1,7 +1,7 @@
 # (c) Copyright IBM Corp. 2021
 # Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)
 ---
-- name:  CMCI Integration Test
+- name:  CMCI BAS Link Integration Test
   #Sets Up a Basic BAS Resource Description with one Resource Group containing one program definition and then cleans up
 
   collections:
@@ -19,50 +19,50 @@
   module_defaults:
     ibm.ibm_zos_cics.cmci_get:
       cmci_host: '{{ cmci_host }}'
-      cmci_port: '{{ cmci_port }}'
+      cmci_port: '{{ cmci_secure_port }}'
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
-      context: '{{ context }}'
-      scope: '{{ scope }}'
+      context: '{{ cmci_context }}'
+      scope: '{{ cmci_scope }}'
       insecure: true
 
     ibm.ibm_zos_cics.cmci_update:
       cmci_host: '{{ cmci_host }}'
-      cmci_port: '{{ cmci_port }}'
+      cmci_port: '{{ cmci_secure_port }}'
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
-      context: '{{ context }}'
-      scope: '{{ scope }}'
+      context: '{{ cmci_context }}'
+      scope: '{{ cmci_scope }}'
       insecure: true
 
 
     ibm.ibm_zos_cics.cmci_delete:
       cmci_host: '{{ cmci_host }}'
-      cmci_port: '{{ cmci_port }}'
+      cmci_port: '{{ cmci_secure_port }}'
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
-      context: '{{ context }}'
-      scope: '{{ scope }}'
+      context: '{{ cmci_context }}'
+      scope: '{{ cmci_scope }}'
       insecure: true
 
 
     ibm.ibm_zos_cics.cmci_action:
       cmci_host: '{{ cmci_host }}'
-      cmci_port: '{{ cmci_port }}'
+      cmci_port: '{{ cmci_secure_port }}'
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
-      context: '{{ context }}'
-      scope: '{{ scope }}'
+      context: '{{ cmci_context }}'
+      scope: '{{ cmci_scope }}'
       insecure: true
 
 
     ibm.ibm_zos_cics.cmci_create:
       cmci_host: '{{ cmci_host }}'
-      cmci_port: '{{ cmci_port }}'
+      cmci_port: '{{ cmci_secure_port }}'
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
-      context: '{{ context }}'
-      scope: '{{ scope }}'
+      context: '{{ cmci_context }}'
+      scope: '{{ cmci_scope }}'
       insecure: true
 
 

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_create_pipeline_failure.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_create_pipeline_failure.yml
@@ -35,6 +35,10 @@
       assert:
         that:
           - result.failed is false
-            # This will need updating when we pull out more specific error messages from the CMCI response.
-            # Expecting the error to contain 'Attribute Configuration File (CONFIGFILE) Error(PIPEDEF_INV_DATA)'
           - result.msg == "CMCI request failed with response \"TABLEERROR\" reason \"DATAERROR\""
+          - result.cpsm_reason == 'DATAERROR'
+          - result.cpsm_response == 'TABLEERROR'
+
+          - result.feedback[0].action == 'CREATE'
+          - result.feedback[0].attribute1 == 'CONFIGFILE'
+          - result.feedback[0].errorcode == '1' #(PIPEDEF_INV_DATA)

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_create_pipeline_failure.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_create_pipeline_failure.yml
@@ -1,7 +1,7 @@
 # (c) Copyright IBM Corp. 2021
 # Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)
 ---
-- name:  CMCI Integration Test
+- name:  CMCI Create Pipeline Failure Integration Test
   collections:
    - ibm.ibm_zos_cics
   hosts: 'localhost'
@@ -11,12 +11,12 @@
     - name: test create pipeline failure
       ibm.ibm_zos_cics.cmci_create:
         cmci_host: '{{ cmci_host }}'
-        cmci_port: '{{ cmci_port }}'
+        cmci_port: '{{ cmci_secure_port }}'
         cmci_user: '{{ cmci_user }}'
         cmci_password: '{{ cmci_password }}'
         insecure: true
-        context: '{{ context }}'
-        scope: '{{ scope }}'
+        context: '{{ cmci_context }}'
+        scope: '{{ cmci_scope }}'
         type: 'CICSDefinitionPipeline'
         create_parameters:
           - name: 'CSD'

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_incorrect_context.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_incorrect_context.yml
@@ -1,7 +1,7 @@
 # (c) Copyright IBM Corp. 2021
 # Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)
 ---
-- name:  CMCI Integration Test
+- name:  CMCI Incorrect Context Integration Test
   collections:
    - ibm.ibm_zos_cics
   hosts: 'localhost'
@@ -11,12 +11,12 @@
     - name: test invalid context
       ibm.ibm_zos_cics.cmci_get:
         cmci_host: '{{ cmci_host }}'
-        cmci_port: '{{ cmci_port }}'
+        cmci_port: '{{ cmci_secure_port }}'
         cmci_user: '{{ cmci_user }}'
         cmci_password: '{{ cmci_password }}'
         insecure: true
         context: 'invalid'
-        scope: '{{ scope }}'
+        scope: '{{ cmci_scope }}'
         type: 'cicsprogram'
       failed_when: false
       register: result

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_incorrect_host.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_incorrect_host.yml
@@ -1,7 +1,7 @@
 # (c) Copyright IBM Corp. 2021
 # Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)
 ---
-- name:  CMCI Integration Test
+- name:  CMCI Incorrect Host Integration Test
   collections:
    - ibm.ibm_zos_cics
   hosts: 'localhost'
@@ -18,12 +18,12 @@
     - name: test invalid host
       ibm.ibm_zos_cics.cmci_get:
         cmci_host: 'DOESNTEXIST'
-        cmci_port: '{{ cmci_port }}'
+        cmci_port: '{{ cmci_secure_port }}'
         cmci_user: '{{ cmci_user }}'
         cmci_password: '{{ cmci_password }}'
         insecure: true
-        context: '{{ context }}'
-        scope: '{{ scope }}'
+        context: '{{ cmci_context }}'
+        scope: '{{ cmci_scope }}'
         type: 'cicsprogram'
       failed_when: false
       register: result

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_incorrect_port.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_incorrect_port.yml
@@ -1,7 +1,7 @@
 # (c) Copyright IBM Corp. 2021
 # Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)
 ---
-- name:  CMCI Integration Test
+- name:  CMCI Incorrect Port Integration Test
   collections:
    - ibm.ibm_zos_cics
   hosts: 'localhost'
@@ -14,8 +14,8 @@
         cmci_port: 12345
         cmci_user: '{{ cmci_user }}'
         cmci_password: '{{ cmci_password }}'
-        context: '{{ context }}'
-        scope: '{{ scope }}'
+        context: '{{ cmci_context }}'
+        scope: '{{ cmci_scope }}'
         type: 'cicsprogram'
       failed_when: false
       register: result

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_incorrect_scheme.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_incorrect_scheme.yml
@@ -1,13 +1,12 @@
 # (c) Copyright IBM Corp. 2021
 # Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)
 ---
-- name:  CMCI Integration Test
+- name:  CMCI Incorrect Scope Integration Test
   collections:
    - ibm.ibm_zos_cics
   hosts: 'localhost'
   gather_facts: 'true'
   vars:
-    http_port: 28953
     http_scope: IYCWEMW1
     python_2_message: >-
       Error performing CMCI request{{ ':' }} ('Connection aborted.',
@@ -22,12 +21,12 @@
     - name: test https with incorrect scheme
       ibm.ibm_zos_cics.cmci_get:
         cmci_host: '{{ cmci_host }}'
-        cmci_port: '{{ cmci_port }}'
+        cmci_port: '{{ cmci_secure_port }}'
         cmci_user: '{{ cmci_user }}'
         cmci_password: '{{ cmci_password }}'
 
-        context: '{{ context }}'
-        scope: '{{ scope }}'
+        context: '{{ cmci_context }}'
+        scope: '{{ cmci_scope }}'
         type: 'cicsprogram'
         scheme: 'http'
         insecure: true
@@ -52,11 +51,11 @@
     - name: test http with incorrect scheme
       ibm.ibm_zos_cics.cmci_get:
         cmci_host: '{{ cmci_host }}'
-        cmci_port: '{{ http_port }}'
+        cmci_port: '{{ cmci_port }}'
         cmci_user: '{{ cmci_user }}'
         cmci_password: '{{ cmci_password }}'
 
-        context: '{{ context }}'
+        context: '{{ cmci_context }}'
         scope: '{{ http_scope }}'
         type: 'cicsprogram'
         scheme: 'https'

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_incorrect_scope.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_incorrect_scope.yml
@@ -1,7 +1,7 @@
 # (c) Copyright IBM Corp. 2021
 # Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)
 ---
-- name:  CMCI Integration Test
+- name:  CMCI Incorrect Scope Integration Test
   collections:
    - ibm.ibm_zos_cics
   hosts: 'localhost'
@@ -11,13 +11,13 @@
     - name: test invalid scope
       ibm.ibm_zos_cics.cmci_get:
         cmci_host: '{{ cmci_host }}'
-        cmci_port: '{{ cmci_port }}'
+        cmci_port: '{{ cmci_secure_port }}'
         cmci_user: '{{ cmci_user }}'
         cmci_password: '{{ cmci_password }}'
         insecure: true
-        context: '{{ context }}'
+        context: '{{ cmci_context }}'
         scope: 'invalid'
-        type: 'cicsprogram'
+        type: 'CICSProgram'
       failed_when: false
       register: result
 

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_insecure_false.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_insecure_false.yml
@@ -1,7 +1,7 @@
 # (c) Copyright IBM Corp. 2020,2021
 # Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)
 ---
-- name:  CMCI Integration Test
+- name:  CMCI Insecure False Integration Test
   collections:
    - ibm.ibm_zos_cics
   hosts: 'localhost'
@@ -11,12 +11,13 @@
     - name: test insecure false
       ibm.ibm_zos_cics.cmci_get:
         cmci_host: '{{ cmci_host }}'
-        cmci_port: '{{ cmci_port }}'
+        cmci_port: '{{ cmci_secure_port }}'
         cmci_user: '{{ cmci_user }}'
         cmci_password: '{{ cmci_password }}'
-        context: '{{ context }}'
-        scope: '{{ scope }}'
+        context: '{{ cmci_context }}'
+        scope: '{{ cmci_scope }}'
         type: 'cicsprogram'
+        insecure: false
         resources:
           filter:
             program: 'DFHLEINI'

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_install_bundle_failure.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_install_bundle_failure.yml
@@ -101,10 +101,21 @@
       assert:
         that:
           - result.failed is false
-            # This will need updating when we pull out more specific error messages from the CMCI response.
-            # Expecting the error to contain 'EXEC CICS command(CSD INSTALL) RESP(INVREQ) RESP2(633)'
-            # Where RESP2(633) is 'Installation of BUNDLE resource resource failed because the resource had no manifest'
           - result.msg == "CMCI request failed with response \"TABLEERROR\" reason \"DATAERROR\""
+          - result.cpsm_reason == 'DATAERROR'
+          - result.cpsm_response == 'TABLEERROR'
+
+          - result.feedback[0].action == 'CSDINSTALL'
+          - result.feedback[0].attribute1 == 'NAME'
+          - result.feedback[0].errorcode == '31'
+
+          - result.feedback[1].action == 'CSDINSTALL'
+          - result.feedback[1].eibfn == 'A20E'
+          - result.feedback[1].eibfn_alt == 'CSD INSTALL'
+          - result.feedback[1].eyu_cicsname == cmci_scope
+          - result.feedback[1].resp == '16'
+          - result.feedback[1].resp2 == '633' #'Installation of BUNDLE resource resource failed because the resource had no manifest'
+          - result.feedback[1].resp_alt == 'INVREQ'
 
 
     - name: 'delete bundle def'

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_install_bundle_failure.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_install_bundle_failure.yml
@@ -1,7 +1,7 @@
 # (c) Copyright IBM Corp. 2021
 # Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)
 ---
-- name:  CMCI Integration Test
+- name:  CMCI Install Bundle Failure Integration Test
   collections:
    - ibm.ibm_zos_cics
   hosts: 'localhost'
@@ -13,29 +13,29 @@
   module_defaults:
     ibm.ibm_zos_cics.cmci_delete:
       cmci_host: '{{ cmci_host }}'
-      cmci_port: '{{ cmci_port }}'
+      cmci_port: '{{ cmci_secure_port }}'
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
-      context: '{{ context }}'
-      scope: '{{ scope }}'
+      context: '{{ cmci_context }}'
+      scope: '{{ cmci_scope }}'
       insecure: true
 
     ibm.ibm_zos_cics.cmci_action:
       cmci_host: '{{ cmci_host }}'
-      cmci_port: '{{ cmci_port }}'
+      cmci_port: '{{ cmci_secure_port }}'
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
-      context: '{{ context }}'
-      scope: '{{ scope }}'
+      context: '{{ cmci_context }}'
+      scope: '{{ cmci_scope }}'
       insecure: true
 
     ibm.ibm_zos_cics.cmci_create:
       cmci_host: '{{ cmci_host }}'
-      cmci_port: '{{ cmci_port }}'
+      cmci_port: '{{ cmci_secure_port }}'
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
-      context: '{{ context }}'
-      scope: '{{ scope }}'
+      context: '{{ cmci_context }}'
+      scope: '{{ cmci_scope }}'
       insecure: true
 
 

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_invalid_credentials.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_invalid_credentials.yml
@@ -1,7 +1,7 @@
 # (c) Copyright IBM Corp. 2021
 # Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)
 ---
-- name:  CMCI Integration Test
+- name:  CMCI Invalid Credentials Integration Test
   collections:
    - ibm.ibm_zos_cics
   hosts: 'localhost'
@@ -14,12 +14,12 @@
     - name: test incorrect username
       ibm.ibm_zos_cics.cmci_get:
         cmci_host: '{{ cmci_host }}'
-        cmci_port: '{{ cmci_port }}'
+        cmci_port: '{{ cmci_secure_port }}'
         cmci_user: 'notme'
         cmci_password: '{{ cmci_password }}'
         insecure: true
-        context: '{{ context }}'
-        scope: '{{ scope }}'
+        context: '{{ cmci_context }}'
+        scope: '{{ cmci_scope }}'
         type: 'cicsprogram'
       failed_when: false
       register: result

--- a/tests/integration/targets/cics_cmci/playbooks/roles/cmci_check_exists/tasks/main.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/roles/cmci_check_exists/tasks/main.yml
@@ -1,0 +1,15 @@
+- name: 'Check if target {{ resource_type }} is installed in {{ context }}/{{ scope }}'
+  delegate_to: 'localhost'
+  ibm.ibm_zos_cics.cmci_get:
+    type: '{{ resource_type }}'
+    context: '{{ context }}'
+    scope: '{{ scope }}'
+    resources:
+      filter: '{{ attributes }}'
+  register: installed_result
+  failed_when: >
+    'cpsm_response' not in installed_result or installed_result.cpsm_response not in ['OK', 'NODATA']
+
+- name: 'Set exists for {{ resource_type }}'
+  set_fact:
+    exists: "{{ installed_result.cpsm_response == 'OK' }}"

--- a/tests/integration/targets/cics_cmci/playbooks/roles/cmci_delete_if_exists/tasks/main.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/roles/cmci_delete_if_exists/tasks/main.yml
@@ -1,0 +1,34 @@
+- name: 'Check if target {{ resource_type }} is installed in {{ context }}/{{ scope }}'
+  include_role:
+    name: cmci_check_exists
+
+- block:
+  - name: 'Delete resource in scope'
+    delegate_to: 'localhost'
+    ibm.ibm_zos_cics.cmci_delete:
+      type: '{{ resource_type }}'
+      context: '{{ context }}'
+      scope: '{{ scope }}'
+      resources:
+        filter: '{{ attributes }}'
+    register: deleted_result
+
+  - name: assert resource was deleted in scope
+    assert:
+      that:
+        - deleted_result is changed
+        - deleted_result.record_count == 1
+
+  - name: 'Check resource was deleted'
+    delegate_to: 'localhost'
+    ibm.ibm_zos_cics.cmci_get:
+      type: '{{ resource_type }}'
+      context: '{{ context }}'
+      scope: '{{ scope }}'
+      resources:
+        filter: '{{ attributes }}'
+    register: discarded_result
+    failed_when: >
+      'cpsm_response' not in discarded_result or discarded_result.cpsm_response not in ['NODATA']
+
+  when: exists

--- a/tests/integration/targets/cics_cmci/playbooks/roles/cmci_disable_discard/tasks/main.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/roles/cmci_disable_discard/tasks/main.yml
@@ -1,0 +1,64 @@
+###
+# DISABLE AND DISCARD file1 in related scope if it exists
+###
+- name: 'Disable resource'
+  delegate_to: 'localhost'
+  ibm.ibm_zos_cics.cmci_action:
+    type: '{{ resource_type }}'
+    action_name: 'DISABLE'
+    context: '{{ context }}'
+    scope: '{{ scope }}'
+    resources:
+      filter: '{{ attributes }}'
+    action_parameters:
+      - name: 'BUSY'
+        value: 'FORCE'
+  register: result
+
+- name: 'Check resource was disabled'
+  delegate_to: 'localhost'
+  ibm.ibm_zos_cics.cmci_get:
+    type: '{{ resource_type }}'
+    context: '{{ context }}'
+    scope: '{{ scope }}'
+    resources:
+      filter: '{{ attributes }}'
+  register: disabled_result
+  retries: 3
+  failed_when: >
+    'cpsm_response' not in result or result.cpsm_response not in ['OK'] or result.records[0].enablestatus != 'DISABLED'
+
+- name: assert file1 was disabled in related region
+  assert:
+    that:
+      - disabled_result is not changed
+      - disabled_result.record_count == 1
+      - disabled_result.records[0].enablestatus == 'DISABLED'
+
+- name: 'Discard resource in scope'
+  delegate_to: 'localhost'
+  ibm.ibm_zos_cics.cmci_delete:
+    type: '{{ resource_type }}'
+    context: '{{ context }}'
+    scope: '{{ scope }}'
+    resources:
+      filter: '{{ attributes }}'
+  register: deleted_result
+
+- name: assert resource was discarded in scope
+  assert:
+    that:
+      - deleted_result is changed
+      - deleted_result.record_count == 1
+
+- name: 'Check resource was discarded'
+  delegate_to: 'localhost'
+  ibm.ibm_zos_cics.cmci_get:
+    type: '{{ resource_type }}'
+    context: '{{ context }}'
+    scope: '{{ scope }}'
+    resources:
+      filter: '{{ attributes }}'
+  register: discarded_result
+  failed_when: >
+    'cpsm_response' not in discarded_result or discarded_result.cpsm_response not in ['NODATA']

--- a/tests/integration/targets/cics_cmci/playbooks/roles/cmci_disable_discard_if_exists/tasks/main.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/roles/cmci_disable_discard_if_exists/tasks/main.yml
@@ -1,0 +1,8 @@
+- name: 'Check if target {{ resource_type }} is installed in {{ context }}/{{ scope }}'
+  include_role:
+    name: cmci_check_exists
+
+- name: 'Disable and discard {{ resource_type }} if it exists'
+  include_role:
+    name: cmci_disable_discard
+  when: exists

--- a/tests/integration/targets/cics_cmci/runme.sh
+++ b/tests/integration/targets/cics_cmci/runme.sh
@@ -15,3 +15,4 @@ ansible-playbook -e "@cmci-variables.yml" playbooks/cmci_create_pipeline_failure
 ansible-playbook -e "@cmci-variables.yml" playbooks/cmci_incorrect_scheme.yml
 ansible-playbook -e "@cmci-variables.yml" playbooks/cmci_bas_link.yml
 ansible-playbook -e "@cmci-variables.yml" playbooks/cmci_bas_install.yml
+ansible-playbook -e "@cmci-variables.yml" playbooks/cmci_bas_install_error.yml

--- a/tests/integration/targets/cics_cmci_missing_requests_library/playbooks/cmci_missing_requests.yml
+++ b/tests/integration/targets/cics_cmci_missing_requests_library/playbooks/cmci_missing_requests.yml
@@ -1,7 +1,7 @@
 # (c) Copyright IBM Corp. 2021
 # Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)
 ---
-- name:  CMCI Integration Test
+- name:  CMCI Missing Requests Integration Test
   collections:
    - ibm.ibm_zos_cics
   hosts: 'localhost'

--- a/tests/integration/targets/cics_cmci_missing_xmltodict_library/playbooks/cmci_missing_xmltodict.yml
+++ b/tests/integration/targets/cics_cmci_missing_xmltodict_library/playbooks/cmci_missing_xmltodict.yml
@@ -1,7 +1,7 @@
 # (c) Copyright IBM Corp. 2021
 # Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)
 ---
-- name:  CMCI Integration Test
+- name:  CMCI Missing XMLToDict Library Integration Test
   collections:
    - ibm.ibm_zos_cics
   hosts: 'localhost'

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1,4 +1,3 @@
-# (c) Copyright IBM Corp. 2020,2021
 docs/make.bat line-endings!skip # Windows batch file requires windows line endings
 plugins/modules/cmci_get.py validate-modules:missing-gplv3-license # Licence is Apache-2.0
 plugins/modules/cmci_action.py validate-modules:missing-gplv3-license # Licence is Apache-2.0

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -1,4 +1,3 @@
-# (c) Copyright IBM Corp. 2020,2021
 docs/make.bat line-endings!skip # Windows batch file requires windows line endings
 plugins/modules/cmci_get.py validate-modules:missing-gplv3-license # Licence is Apache-2.0
 plugins/modules/cmci_action.py validate-modules:missing-gplv3-license # Licence is Apache-2.0


### PR DESCRIPTION
- Added support for cmci feedback include BAS feedback errors
- Added new integration test with BAS installation error to cover feedback support
- Updated names on integration tests
- Updated cmci_variables template and all int tests to explicitly use secure/ non-secure ports
- Removed copyright statements from ignore.txt files: Can't have a # on the first line of those files
