### PR TITLE
Update URL to use IBM Docs and link to latest CICS

### DIFF
--- a/docs/ansible_content.rst
+++ b/docs/ansible_content.rst
@@ -21,7 +21,7 @@ the `CMCI REST API`_ of the CICS® management client interface (CMCI) for system
 management.
 
 .. _CMCI REST API:
-   https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/fundamentals/cpsm/cpsm-cmci-restfulapi-overview.html
+   https://www.ibm.com/docs/en/cics-ts/latest?topic=cmci-how-it-works-rest-api
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -53,7 +53,7 @@ This collection can manage CICS and CICSPlex® SM resources and definitions by c
    https://github.com/IBM/z_ansible_collections_samples/tree/master/zos_subsystems/cics
 
 .. _CMCI REST API:
-   https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/fundamentals/cpsm/cpsm-cmci-restfulapi-overview.html
+   https://www.ibm.com/docs/en/cics-ts/latest?topic=cmci-how-it-works-rest-api
 
 .. _the documentation site:
    https://ibm.github.io/z_ansible_collections_doc/ibm_zos_cics/docs/ansible_content.html

--- a/docs/source/requirements.rst
+++ b/docs/source/requirements.rst
@@ -26,7 +26,7 @@ A control node is any machine with Ansible® installed. You can run commands and
 .. _OpenSSH:
    https://www.openssh.com/
 .. _CMCI REST API:
-   https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/fundamentals/cpsm/cpsm-cmci-restfulapi-overview.html
+   https://www.ibm.com/docs/en/cics-ts/latest?topic=cmci-how-it-works-rest-api
 
 
 Managed node

--- a/docs/source/requirements_managed.rst
+++ b/docs/source/requirements_managed.rst
@@ -63,13 +63,13 @@ your managed node must also follow the requirements of those collections, for ex
 If you use the CICS collection alone but don't delegate the CICS tasks to your localhost, your managed node must also follow the `IBM z/OS core managed node requirements`_ except that IBM Z Open Automation Utilities (ZOAU) is not required.
 
 .. _z/OS OpenSSH:
-   https://www.ibm.com/support/knowledgecenter/SSLTBW_2.2.0/com.ibm.zos.v2r2.e0za100/ch1openssh.htm
+   https://www.ibm.com/docs/en/zos/latest?topic=descriptions-zos-openssh
 
 .. _CMCI connection:
-   https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/configuring/cmci/clientapi_setup.html
+   https://www.ibm.com/docs/en/cics-ts/latest?topic=configuring-setting-up-cmci
 
 .. _CMCI REST API:
-   https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/fundamentals/cpsm/cpsm-cmci-restfulapi-overview.html
+   https://www.ibm.com/docs/en/cics-ts/latest?topic=cmci-how-it-works-rest-api
 
 .. _IBM z/OS core managed node requirements:
    https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/requirements_managed.html

--- a/plugins/doc_fragments/cmci.py
+++ b/plugins/doc_fragments/cmci.py
@@ -72,7 +72,7 @@ options:
         C(PLEX1). To determine whether a CMAS can be specified as I(context),
         see the B(CMAS context) entry in the CICSPlex SM resource table
         reference of a resource. For example, according to the
-        L(PROGRAM resource table,https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.6.0/reference-cpsm-restables/cpsm-restables/PROGRAMtab.html),
+        L(PROGRAM resource table,https://www.ibm.com/docs/en/cics-ts/latest?topic=tables-program-resource-table),
         CMAS context is not supported for PROGRAM.
       - If CMCI is installed in a single region (SMSS), I(context) is the
         APPLID of the CICS region associate with the request.
@@ -96,7 +96,7 @@ options:
       - The CMCI external resource name that maps to the target CICS or CICSPlex
         SM resource type.
         For a list of CMCI external resource names, see
-        L(CMCI resource names,https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/cmci/clientapi_resources.html).
+        L(CMCI resource names,https://www.ibm.com/docs/en/cics-ts/latest?topic=reference-cmci-resource-names).
     type: str
     required: true
   scheme:
@@ -144,11 +144,11 @@ options:
             different filter operators, and the ability to compose filters with
             C(and) and C(or) operators, see the C(complex_filter) parameter.
           - For more details, see
-            L(How to build a filter expression,https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/system-programming/cpsm/eyup1a0.html).
+            L(How to build a filter expression,https://www.ibm.com/docs/en/cics-ts/latest?topic=expressions-how-build-filter-expression).
           - For examples, see M(cmci_get).
           - For supported attributes of different resource types, see their
             resource table reference, for example,
-            L(PROGDEF resource table reference,https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.6.0/reference-cpsm-restables/cpsm-restables/PROGDEFtab.html).
+            L(PROGDEF resource table reference,https://www.ibm.com/docs/en/cics-ts/latest?topic=tables-progdef-resource-table).
         type: dict
         required: false
       complex_filter:
@@ -196,7 +196,7 @@ options:
               - The name of a resource table attribute on which to filter.
               - For supported attributes of different resource types, see their
                 resource table reference, for example,
-                L(PROGDEF resource table reference, https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.6.0/reference-cpsm-restables/cpsm-restables/PROGDEFtab.html).
+                L(PROGDEF resource table reference, https://www.ibm.com/docs/en/cics-ts/latest?topic=tables-progdef-resource-table).
             type: str
             required: false
           operator:
@@ -229,7 +229,7 @@ options:
               - The value by which you are to filter the resource attributes.
               - The value must be a valid one for the resource table attribute
                 as documented in the resource table reference, for example,
-                L(PROGDEF resource table reference,https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.6.0/reference-cpsm-restables/cpsm-restables/PROGDEFtab.html).
+                L(PROGDEF resource table reference,https://www.ibm.com/docs/en/cics-ts/latest?topic=tables-progdef-resource-table).
             type: str
             required: false
       get_parameters:
@@ -241,7 +241,7 @@ options:
           the "Valid CPSM operations" table. For example, the valid parameters
           for identifying a PROGDEF resource are CICSSYS, CSDGROUP and RESGROUP,
           as found in the
-          L(PROGDEF resource table reference,https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.6.0/reference-cpsm-restables/cpsm-restables/PROGDEFtab.html).
+          L(PROGDEF resource table reference,https://www.ibm.com/docs/en/cics-ts/latest?topic=tables-progdef-resource-table).
         type: list
         elements: dict
         suboptions:
@@ -263,7 +263,7 @@ options:
       - The resource attributes to be created or updated. Available attributes
         can be found in the CICSPlex® SM resource table reference for the
         target resource type, for example,
-        L(PROGDEF resource table reference,https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.6.0/reference-cpsm-restables/cpsm-restables/PROGDEFtab.html).
+        L(PROGDEF resource table reference,https://www.ibm.com/docs/en/cics-ts/latest?topic=tables-progdef-resource-table).
     type: dict
     required: false
 '''

--- a/plugins/modules/cmci_action.py
+++ b/plugins/modules/cmci_action.py
@@ -16,9 +16,9 @@ description:
     initiating PUT requests via the CMCI REST API. The CMCI REST API can be
     configured in CICSPlex SM or stand-alone regions (SMSS). For information
     about the API, see
-    L(CMCI REST API,https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/cmci/clientapi_overview.html).
+    L(CMCI REST API,https://www.ibm.com/docs/en/cics-ts/latest?topic=programming-cmci-rest-api-reference).
     For information about how to compose PUT requests, see
-    L(CMCI PUT requests,https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/cmci/clientapi_put.html).
+    L(CMCI PUT requests,https://www.ibm.com/docs/en/cics-ts/latest?topic=requests-cmci-put).
 author:
   - Stewart Francis (@stewartfrancis)
   - Tom Latham (@Tom-Latham)
@@ -33,7 +33,7 @@ options:
       The name of the target action. To find the name of the appropriate action,
       consult the CICSPlex SM resource tables for the target resource type. For
       example, the
-      L(PROGRAM resource table reference,https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.6.0/reference-cpsm-restables/cpsm-restables/PROGRAMtab.html)
+      L(PROGRAM resource table reference,https://www.ibm.com/docs/en/cics-ts/latest?topic=tables-program-resource-table)
       lists the eligible actions for CICS programs.
     type: str
     required: true
@@ -45,7 +45,7 @@ options:
       listed in the PERFORM SET operation section of the "Valid CPSM operations"
       table. For example, the valid parameters for a PROGDEF CSDCOPY action are
       C(AS_RESOURCE), C(DUPACTION) and C(TO_CSDGROUP), as found in the
-      L(PROGDEF resource table reference,https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.6.0/reference-cpsm-restables/cpsm-restables/PROGDEFtab.html).
+      L(PROGDEF resource table reference,https://www.ibm.com/docs/en/cics-ts/latest?topic=tables-progdef-resource-table).
     type: list
     elements: dict
     suboptions:
@@ -113,28 +113,28 @@ cpsm_reason:
   description:
     - The character value of the REASON code returned by each CICSPlex SM API
       command. For a list of REASON character values, see
-      https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/commands-cpsm/eyup2ky.html.
+      https://www.ibm.com/docs/en/cics-ts/latest?topic=values-eyuda-reason-in-alphabetical-order.
   returned: success
   type: str
 cpsm_reason_code:
   description:
     - The numeric value of the REASON code returned by each CICSPlex SM API
       command. For a list of REASON numeric values, see
-      https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/commands-cpsm/eyup2kw.html.
+      https://www.ibm.com/docs/en/cics-ts/latest?topic=values-eyuda-reason-in-numerical-order.
   returned: success
   type: int
 cpsm_response:
   description:
     - The character value of the RESPONSE code returned by each CICSPlex SM API
       command. For a list of RESPONSE character values, see
-      https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/commands-cpsm/eyup2kx.html.
+      https://www.ibm.com/docs/en/cics-ts/latest?topic=values-eyuda-response-in-alphabetical-order.
   returned: success
   type: str
 cpsm_response_code:
   description:
     - The numeric value of the RESPONSE code returned by each CICSPlex SM API
       command. For a list of RESPONSE numeric values, see
-      https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/commands-cpsm/eyup2kv.html.
+      https://www.ibm.com/docs/en/cics-ts/latest?topic=values-eyuda-response-in-numerical-order.
   returned: success
   type: str
 http_status:

--- a/plugins/modules/cmci_create.py
+++ b/plugins/modules/cmci_create.py
@@ -16,9 +16,9 @@ description:
     repositories, by initiating POST requests via the CMCI REST API. The CMCI
     REST API can be configured in CICSPlex SM or stand-alone regions (SMSS). For
     information about the API, see
-    L(CMCI REST API,https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/cmci/clientapi_overview.html).
+    L(CMCI REST API,https://www.ibm.com/docs/en/cics-ts/latest?topic=programming-cmci-rest-api-reference).
     For information about how to compose POST requests, see
-    L(CMCI POST requests,https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/cmci/clientapi_post.html).
+    L(CMCI POST requests,https://www.ibm.com/docs/en/cics-ts/latest?topic=requests-cmci-post).
 author:
   - Stewart Francis (@stewartfrancis)
   - Tom Latham (@Tom-Latham)
@@ -36,7 +36,7 @@ options:
       operation section of the "Valid CPSM operations" table. For example, the
       valid parameters for a PROGDEF CREATE operation are CSD and RESGROUP, as
       found in the
-      L(PROGDEF resource table reference,https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.6.0/reference-cpsm-restables/cpsm-restables/PROGDEFtab.html).
+      L(PROGDEF resource table reference,https://www.ibm.com/docs/en/cics-ts/latest?topic=tables-progdef-resource-table).
     type: list
     elements: dict
     suboptions:
@@ -88,28 +88,28 @@ cpsm_reason:
   description:
     - The character value of the REASON code returned by each CICSPlex SM API
       command. For a list of REASON character values, see
-      https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/commands-cpsm/eyup2ky.html.
+      https://www.ibm.com/docs/en/cics-ts/latest?topic=values-eyuda-reason-in-alphabetical-order.
   returned: success
   type: str
 cpsm_reason_code:
   description:
     - The numeric value of the REASON code returned by each CICSPlex SM API
       command. For a list of REASON numeric values, see
-      https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/commands-cpsm/eyup2kw.html.
+      https://www.ibm.com/docs/en/cics-ts/latest?topic=values-eyuda-reason-in-numerical-order.
   returned: success
   type: int
 cpsm_response:
   description:
     - The character value of the RESPONSE code returned by each CICSPlex SM API
       command. For a list of RESPONSE character values, see
-      https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/commands-cpsm/eyup2kx.html.
+      https://www.ibm.com/docs/en/cics-ts/latest?topic=values-eyuda-response-in-alphabetical-order.
   returned: success
   type: str
 cpsm_response_code:
   description:
     - The numeric value of the RESPONSE code returned by each CICSPlex SM API
       command. For a list of RESPONSE numeric values, see
-      https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/commands-cpsm/eyup2kv.html.
+      https://www.ibm.com/docs/en/cics-ts/latest?topic=values-eyuda-response-in-numerical-order.
   returned: success
   type: str
 http_status:

--- a/plugins/modules/cmci_delete.py
+++ b/plugins/modules/cmci_delete.py
@@ -16,9 +16,9 @@ description:
     from CICS regions, by initiating DELETE requests via the CMCI REST API. The
     CMCI REST API can be configured in CICSPlex SM or stand-alone regions
     (SMSS). For information about the API, see
-    L(CMCI REST API,https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/cmci/clientapi_overview.html).
+    L(CMCI REST API,https://www.ibm.com/docs/en/cics-ts/latest?topic=programming-cmci-rest-api-reference).
     For information about how to compose DELETE requests, see
-    L(CMCI DELETE requests, https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/cmci/clientapi_delete.html).
+    L(CMCI DELETE requests, https://www.ibm.com/docs/en/cics-ts/latest?topic=requests-cmci-delete).
 author:
   - Stewart Francis (@stewartfrancis)
   - Tom Latham (@Tom-Latham)
@@ -73,28 +73,28 @@ cpsm_reason:
   description:
     - The character value of the REASON code returned by each CICSPlex SM API
       command. For a list of REASON character values, see
-      https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/commands-cpsm/eyup2ky.html.
+      https://www.ibm.com/docs/en/cics-ts/latest?topic=values-eyuda-reason-in-alphabetical-order.
   returned: success
   type: str
 cpsm_reason_code:
   description:
     - The numeric value of the REASON code returned by each CICSPlex SM API
       command. For a list of REASON numeric values, see
-      https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/commands-cpsm/eyup2kw.html.
+      https://www.ibm.com/docs/en/cics-ts/latest?topic=values-eyuda-reason-in-numerical-order.
   returned: success
   type: int
 cpsm_response:
   description:
     - The character value of the RESPONSE code returned by each CICSPlex SM API
       command. For a list of RESPONSE character values, see
-      https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/commands-cpsm/eyup2kx.html.
+      https://www.ibm.com/docs/en/cics-ts/latest?topic=values-eyuda-response-in-alphabetical-order.
   returned: success
   type: str
 cpsm_response_code:
   description:
     - The numeric value of the RESPONSE code returned by each CICSPlex SM API
       command. For a list of RESPONSE numeric values, see
-      https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/commands-cpsm/eyup2kv.html.
+      https://www.ibm.com/docs/en/cics-ts/latest?topic=values-eyuda-response-in-numerical-order.
   returned: success
   type: str
 http_status:

--- a/plugins/modules/cmci_get.py
+++ b/plugins/modules/cmci_get.py
@@ -16,9 +16,9 @@ description:
     resources from CICS regions, by initiating GET requests via the CMCI REST
     API. The CMCI REST API can be configured in CICSPlex SM or stand-alone
     regions (SMSS). For information about the API, see
-    L(CMCI REST API,https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/cmci/clientapi_overview.html).
+    L(CMCI REST API,https://www.ibm.com/docs/en/cics-ts/latest?topic=programming-cmci-rest-api-reference).
     For information about how to compose GET requests, see
-    L(CMCI GET requests,https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/cmci/clientapi_get.html).
+    L(CMCI GET requests,https://www.ibm.com/docs/en/cics-ts/latest?topic=requests-cmci-get).
 author:
   - Stewart Francis (@stewartfrancis)
   - Tom Latham (@Tom-Latham)
@@ -127,28 +127,28 @@ cpsm_reason:
   description:
     - The character value of the REASON code returned by each CICSPlex SM API
       command. For a list of REASON character values, see
-      https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/commands-cpsm/eyup2ky.html.
+      https://www.ibm.com/docs/en/cics-ts/latest?topic=values-eyuda-reason-in-alphabetical-order.
   returned: success
   type: str
 cpsm_reason_code:
   description:
     - The numeric value of the REASON code returned by each CICSPlex SM API
       command. For a list of REASON numeric values, see
-      https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/commands-cpsm/eyup2kw.html.
+      https://www.ibm.com/docs/en/cics-ts/latest?topic=values-eyuda-reason-in-numerical-order.
   returned: success
   type: int
 cpsm_response:
   description:
     - The character value of the RESPONSE code returned by each CICSPlex SM API
       command. For a list of RESPONSE character values, see
-      https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/commands-cpsm/eyup2kx.html.
+      https://www.ibm.com/docs/en/cics-ts/latest?topic=values-eyuda-response-in-alphabetical-order.
   returned: success
   type: str
 cpsm_response_code:
   description:
     - The numeric value of the RESPONSE code returned by each CICSPlex SM API
       command. For a list of RESPONSE numeric values, see
-      https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/commands-cpsm/eyup2kv.html.
+      https://www.ibm.com/docs/en/cics-ts/latest?topic=values-eyuda-response-in-numerical-order.
   returned: success
   type: str
 http_status:

--- a/plugins/modules/cmci_update.py
+++ b/plugins/modules/cmci_update.py
@@ -16,9 +16,9 @@ description:
     initiating PUT requests via the CMCI REST API. The CMCI REST API can be
     configured in CICSPlex SM or stand-alone regions (SMSS). For information
     about the API, see
-    L(CMCI REST API, https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/cmci/clientapi_overview.html).
+    L(CMCI REST API, https://www.ibm.com/docs/en/cics-ts/latest?topic=programming-cmci-rest-api-reference).
     For information about how to compose PUT requests, see
-    L(CMCI PUT requests,https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/cmci/clientapi_put.html).
+    L(CMCI PUT requests,https://www.ibm.com/docs/en/cics-ts/latest?topic=requests-cmci-put).
 author:
   - Stewart Francis (@stewartfrancis)
   - Tom Latham (@Tom-Latham)
@@ -37,7 +37,7 @@ options:
       operation section of the "Valid CPSM operations" table. For example, the
       only valid parameter for a PROGDEF UPDATE operation is CSD, as found in
       the
-      L(PROGDEF resource table reference,https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.6.0/reference-cpsm-restables/cpsm-restables/PROGDEFtab.html).
+      L(PROGDEF resource table reference,https://www.ibm.com/docs/en/cics-ts/latest?topic=tables-progdef-resource-table).
     type: list
     elements: dict
     suboptions:
@@ -93,28 +93,28 @@ cpsm_reason:
   description:
     - The character value of the REASON code returned by each CICSPlex SM API
       command. For a list of REASON character values, see
-      https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/commands-cpsm/eyup2ky.html.
+      https://www.ibm.com/docs/en/cics-ts/latest?topic=values-eyuda-reason-in-alphabetical-order.
   returned: success
   type: str
 cpsm_reason_code:
   description:
     - The numeric value of the REASON code returned by each CICSPlex SM API
       command. For a list of REASON numeric values, see
-      https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/commands-cpsm/eyup2kw.html.
+      https://www.ibm.com/docs/en/cics-ts/latest?topic=values-eyuda-reason-in-numerical-order.
   returned: success
   type: int
 cpsm_response:
   description:
     - The character value of the RESPONSE code returned by each CICSPlex SM API
       command. For a list of RESPONSE character values, see
-      https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/commands-cpsm/eyup2kx.html.
+      https://www.ibm.com/docs/en/cics-ts/latest?topic=values-eyuda-response-in-alphabetical-order.
   returned: success
   type: str
 cpsm_response_code:
   description:
     - The numeric value of the RESPONSE code returned by each CICSPlex SM API
       command. For a list of RESPONSE numeric values, see
-      https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/commands-cpsm/eyup2kv.html.
+      https://www.ibm.com/docs/en/cics-ts/latest?topic=values-eyuda-response-in-numerical-order.
   returned: success
   type: str
 http_status:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Resolves issue #113.

Update URLs to IBM Documentation format, consistently include `/en/` in those URLs, and link to the latest CICS TS and z/OS releases.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
cmci_action
cmci_create
cmci_delete
cmci_get
cmci_update

##### ADDITIONAL INFORMATION
Issue #113 sufficiently describes problem.

@stewartfrancis Can you review the PR.