### PR TITLE
Added `fail_on_nodata` attribute to the cmci_get task

### DIFF
--- a/plugins/module_utils/cmci.py
+++ b/plugins/module_utils/cmci.py
@@ -418,8 +418,8 @@ class AnsibleCMCIModule(object):
                     feedback = errors_node[FEEDBACK]
                     self.result[FEEDBACK] = read_error_node(feedback)
 
-            # Non-OK CPSM responses fail the module
-            if cpsm_response_code != 1024:
+            # If CPSM response code not in Valid List, fail the module
+            if self.get_ok_cpsm_response_codes().count(cpsm_response_code) == 0:
                 self._fail(
                     'CMCI request failed with response "{0}" reason "{1}"'
                     .format(
@@ -436,6 +436,9 @@ class AnsibleCMCIModule(object):
                 'Could not parse CMCI response: missing node "{0}"'
                 .format(e.args[0])
             )
+    
+    def get_ok_cpsm_response_codes(self):
+        return [1024]
 
     def init_url(self):  # type: () -> str
         t = self._p.get(TYPE).lower()

--- a/tests/integration/targets/cics_cmci/cmci-variables.yml.template
+++ b/tests/integration/targets/cics_cmci/cmci-variables.yml.template
@@ -7,4 +7,7 @@ cmci_secure_port: 28951
 cmci_user: __user__
 cmci_password: __password__
 cmci_context: CICSEX56
-cmci_scope: IYCWEMW2
+cmci_scope_https: IYCWEMW2
+cmci_scope_http: IYCWEMW1
+cmci_scope_alternate_1: IYCWEML1
+cmci_scope_alternate_2: IYCWEMM1

--- a/tests/integration/targets/cics_cmci/cmci-variables.yml.template
+++ b/tests/integration/targets/cics_cmci/cmci-variables.yml.template
@@ -9,5 +9,5 @@ cmci_password: __password__
 cmci_context: CICSEX56
 cmci_scope_https: IYCWEMW2
 cmci_scope_http: IYCWEMW1
-cmci_scope_alternate_1: IYCWEML1
-cmci_scope_alternate_2: IYCWEMM1
+cmci_scope_region_1: IYCWEML1
+cmci_scope_region_2: IYCWEMM1

--- a/tests/integration/targets/cics_cmci/playbooks/cics_cmci_http.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cics_cmci_http.yml
@@ -5,11 +5,12 @@
   collections:
    - ibm.ibm_zos_cics
   hosts: 'localhost'
-  gather_facts: 'false'
+  gather_facts: false
   vars:
     csdgroup: 'HTTPTEST'
     program: 'HTTPTEST'
-    http_scope: IYCWEMW1
+    program_2: 'HTTPTES2'
+    program_filter: 'HTTPTES*'
 
   module_defaults:
     ibm.ibm_zos_cics.cmci_get:
@@ -18,7 +19,7 @@
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
       context: '{{ cmci_context }}'
-      scope: '{{ http_scope }}'
+      scope: '{{ cmci_scope_http }}'
       insecure: true
       scheme: 'http'
 
@@ -29,7 +30,7 @@
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
       context: '{{ cmci_context }}'
-      scope: '{{ http_scope }}'
+      scope: '{{ cmci_scope_http }}'
       insecure: true
       scheme: 'http'
 
@@ -40,7 +41,7 @@
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
       context: '{{ cmci_context }}'
-      scope: '{{ http_scope }}'
+      scope: '{{ cmci_scope_http }}'
       insecure: true
       scheme: 'http'
 
@@ -51,7 +52,7 @@
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
       context: '{{ cmci_context }}'
-      scope: '{{ http_scope }}'
+      scope: '{{ cmci_scope_http }}'
       insecure: true
       scheme: 'http'
 
@@ -62,7 +63,7 @@
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
       context: '{{ cmci_context }}'
-      scope: '{{ http_scope }}'
+      scope: '{{ cmci_scope_http }}'
       insecure: true
       scheme: 'http'
 
@@ -169,9 +170,6 @@
           - result.record_count == 1
           - result.records[0].program == program
 
-    - name: debug 1
-      debug:
-        msg: "{{ result }}"
 
     - name: 'HTTP Disable program'
       delegate_to: 'localhost'
@@ -194,12 +192,7 @@
                   - attribute: 'USECOUNT'
                     operator: 'LT'
                     value: '1'
-
       register: result
-
-    - name: debug 2
-      debug:
-        msg: "{{ result }}"
 
     - name: assert 5
       assert:
@@ -227,6 +220,68 @@
           - result.cpsm_response == 'OK'
           - result.record_count == 1
           - result.success_count == 1
+    
+
+    - name: 'HTTP Create progdef 2'
+      delegate_to: 'localhost'
+      ibm.ibm_zos_cics.cmci_create:
+        type: 'CICSDefinitionProgram'
+        attributes:
+          name: '{{ program_2 }}'
+          csdgroup: '{{ csdgroup }}'
+        create_parameters:
+          - name: 'CSD'
+      register: result
+
+    - name: assert program_2 created
+      assert:
+        that:
+          - result is changed
+          - result.cpsm_response == 'OK'
+          - result.record_count == 1
+          - result.records[0].name == program_2
+
+    
+    - name: 'HTTP Check All Records Returned'
+      delegate_to: 'localhost'
+      ibm.ibm_zos_cics.cmci_get:
+        type: 'CICSDefinitionProgram'
+        resources:
+          filter:
+            name: '{{ program_filter }}'
+          get_parameters:
+            - name: 'CSDGROUP'
+              value: '{{ csdgroup }}'
+      register: result
+
+    - name: assert record_count is 2
+      assert:
+        that:
+          - result is not changed
+          - result.cpsm_response == 'OK'
+          - result.record_count == 2
+    
+
+    - name: 'HTTP Check record count attribute'
+      delegate_to: 'localhost'
+      ibm.ibm_zos_cics.cmci_get:
+        type: 'CICSDefinitionProgram'
+        record_count: 1
+        resources:
+          filter:
+            name: '{{ program_filter }}'
+          get_parameters:
+            - name: 'CSDGROUP'
+              value: '{{ csdgroup }}'
+      register: result
+    
+    - name: assert record_count attribute
+      assert:
+        that:
+          - result is not changed
+          - result.cpsm_response == 'OK'
+          - result.record_count == 2
+          - result.records|length == 1
 
 
     - name: 'HTTP Delete progdef'
@@ -248,3 +303,75 @@
           - result.cpsm_response == 'OK'
           - result.record_count == 1
           - result.success_count == 1
+
+
+    - name: 'HTTP Delete progdef2'
+      delegate_to: 'localhost'
+      ibm.ibm_zos_cics.cmci_delete:
+        type: 'CICSDefinitionProgram'
+        resources:
+          filter:
+            NAME: '{{ program_2 }}'
+          get_parameters:
+            - name: 'CSDGROUP'
+              value: '{{ csdgroup }}'
+      register: result
+    
+    - name: assert program_2 deleted
+      assert:
+        that:
+          - result is changed
+          - result.cpsm_response == 'OK'
+          - result.record_count == 1
+          - result.success_count == 1
+
+
+    - name: 'HTTP fail_on_nodata default'
+      delegate_to: 'localhost'
+      ibm.ibm_zos_cics.cmci_get:
+        type: 'CICSDefinitionProgram'
+        resources:
+          filter:
+            name: '{{ program_filter }}'
+          get_parameters:
+            - name: 'CSDGROUP'
+              value: '{{ csdgroup }}'
+      register: result
+      failed_when: >
+        'cpsm_response_code' not in result or result.cpsm_response_code not in [1024, 1027]
+    
+    - name: assert fail_on_nodata attribute default
+      assert:
+        that:
+          - result is not changed
+          - result.failed == false
+          - result.cpsm_response == 'NODATA'
+          - result.cpsm_response_code == 1027
+          - result.record_count == 0
+          - result.msg is defined
+          - result.failed_when_result is defined
+
+
+    - name: 'HTTP fail_on_nodata'
+      delegate_to: 'localhost'
+      ibm.ibm_zos_cics.cmci_get:
+        type: 'CICSDefinitionProgram'
+        fail_on_nodata: False
+        resources:
+          filter:
+            name: '{{ program_filter }}'
+          get_parameters:
+            - name: 'CSDGROUP'
+              value: '{{ csdgroup }}'
+      register: result
+    
+    - name: assert fail_on_nodata attribute false
+      assert:
+        that:
+          - result is not changed
+          - result.failed == false
+          - result.cpsm_response == 'NODATA'
+          - result.cpsm_response_code == 1027
+          - result.record_count == 0
+          - result.msg is not defined
+          - result.failed_when_result is not defined

--- a/tests/integration/targets/cics_cmci/playbooks/cics_cmci_https.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cics_cmci_https.yml
@@ -5,20 +5,21 @@
   collections:
    - ibm.ibm_zos_cics
   hosts: 'localhost'
-  gather_facts: 'false'
+  gather_facts: false
   vars:
     csdgroup: 'ANSITEST'
     program: 'ANSITEST'
+    program_2: 'ANSITES2'
+    program_filter: 'ANSITES*'
 
   module_defaults:
-    # No support for supplying custom module_defaults groups yet :(
     ibm.ibm_zos_cics.cmci_get:
       cmci_host: '{{ cmci_host }}'
       cmci_port: '{{ cmci_secure_port }}'
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
       context: '{{ cmci_context }}'
-      scope: '{{ cmci_scope }}'
+      scope: '{{ cmci_scope_https }}'
       insecure: true
 
     ibm.ibm_zos_cics.cmci_update:
@@ -27,7 +28,7 @@
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
       context: '{{ cmci_context }}'
-      scope: '{{ cmci_scope }}'
+      scope: '{{ cmci_scope_https }}'
       insecure: true
 
 
@@ -37,7 +38,7 @@
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
       context: '{{ cmci_context }}'
-      scope: '{{ cmci_scope }}'
+      scope: '{{ cmci_scope_https }}'
       insecure: true
 
 
@@ -47,7 +48,7 @@
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
       context: '{{ cmci_context }}'
-      scope: '{{ cmci_scope }}'
+      scope: '{{ cmci_scope_https }}'
       insecure: true
 
 
@@ -57,7 +58,7 @@
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
       context: '{{ cmci_context }}'
-      scope: '{{ cmci_scope }}'
+      scope: '{{ cmci_scope_https }}'
       insecure: true
 
   tasks:
@@ -163,9 +164,6 @@
           - result.record_count == 1
           - result.records[0].program == program
 
-    - name: debug 1
-      debug:
-        msg: "{{ result }}"
 
     - name: 'disable program'
       delegate_to: 'localhost'
@@ -188,12 +186,7 @@
                   - attribute: 'USECOUNT'
                     operator: 'LT'
                     value: '1'
-
       register: result
-
-    - name: debug 2
-      debug:
-        msg: "{{ result }}"
 
     - name: assert 5
       assert:
@@ -222,6 +215,68 @@
           - result.record_count == 1
           - result.success_count == 1
 
+    
+    - name: 'create progdef2'
+      delegate_to: 'localhost'
+      ibm.ibm_zos_cics.cmci_create:
+        type: 'CICSDefinitionProgram'
+        attributes:
+          name: '{{ program_2 }}'
+          csdgroup: '{{ csdgroup }}'
+        create_parameters:
+          - name: 'CSD'
+      register: result
+
+    - name: assert program_2 created
+      assert:
+        that:
+          - result is changed
+          - result.cpsm_response == 'OK'
+          - result.record_count == 1
+          - result.records[0].name == program_2
+    
+
+    - name: 'Check All Records Returned'
+      delegate_to: 'localhost'
+      ibm.ibm_zos_cics.cmci_get:
+        type: 'CICSDefinitionProgram'
+        resources:
+          filter:
+            name: '{{ program_filter }}'
+          get_parameters:
+            - name: 'CSDGROUP'
+              value: '{{ csdgroup }}'
+      register: result
+
+    - name: assert record_count is 2
+      assert:
+        that:
+          - result is not changed
+          - result.cpsm_response == 'OK'
+          - result.record_count == 2
+    
+
+    - name: 'Check record count attribute'
+      delegate_to: 'localhost'
+      ibm.ibm_zos_cics.cmci_get:
+        type: 'CICSDefinitionProgram'
+        record_count: 1
+        resources:
+          filter:
+            name: '{{ program_filter }}'
+          get_parameters:
+            - name: 'CSDGROUP'
+              value: '{{ csdgroup }}'
+      register: result
+    
+    - name: assert record_count attribute
+      assert:
+        that:
+          - result is not changed
+          - result.cpsm_response == 'OK'
+          - result.record_count == 2
+          - result.records|length == 1
+
 
     - name: 'delete progdef'
       delegate_to: 'localhost'
@@ -242,3 +297,75 @@
           - result.cpsm_response == 'OK'
           - result.record_count == 1
           - result.success_count == 1
+    
+
+    - name: 'Delete progdef2'
+      delegate_to: 'localhost'
+      ibm.ibm_zos_cics.cmci_delete:
+        type: 'CICSDefinitionProgram'
+        resources:
+          filter:
+            NAME: '{{ program_2 }}'
+          get_parameters:
+            - name: 'CSDGROUP'
+              value: '{{ csdgroup }}'
+      register: result
+    
+    - name: assert program_2 deleted
+      assert:
+        that:
+          - result is changed
+          - result.cpsm_response == 'OK'
+          - result.record_count == 1
+          - result.success_count == 1
+
+
+    - name: 'fail_on_nodata default'
+      delegate_to: 'localhost'
+      ibm.ibm_zos_cics.cmci_get:
+        type: 'CICSDefinitionProgram'
+        resources:
+          filter:
+            name: '{{ program_filter }}'
+          get_parameters:
+            - name: 'CSDGROUP'
+              value: '{{ csdgroup }}'
+      register: result
+      failed_when: >
+        'cpsm_response_code' not in result or result.cpsm_response_code not in [1024, 1027]
+    
+    - name: assert fail_on_nodata attribute default
+      assert:
+        that:
+          - result is not changed
+          - result.failed == false
+          - result.cpsm_response == 'NODATA'
+          - result.cpsm_response_code == 1027
+          - result.record_count == 0
+          - result.msg is defined # Present when ansible task fails - exception caught by 'failed_when' attribute for testing
+          - result.failed_when_result is defined
+
+
+    - name: 'fail_on_nodata False'
+      delegate_to: 'localhost'
+      ibm.ibm_zos_cics.cmci_get:
+        type: 'CICSDefinitionProgram'
+        fail_on_nodata: False
+        resources:
+          filter:
+            name: '{{ program_filter }}'
+          get_parameters:
+            - name: 'CSDGROUP'
+              value: '{{ csdgroup }}'
+      register: result
+    
+    - name: assert fail_on_nodata attribute false
+      assert:
+        that:
+          - result is not changed
+          - result.failed == false
+          - result.cpsm_response == 'NODATA'
+          - result.cpsm_response_code == 1027
+          - result.record_count == 0
+          - result.msg is not defined
+          - result.failed_when_result is not defined

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_bas_install.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_bas_install.yml
@@ -8,15 +8,15 @@
   collections:
    - ibm.ibm_zos_cics
   hosts: 'localhost'
-  gather_facts: 'false'
+  gather_facts: false
   vars:
     program: 'ANSIPROG'
     resource_description: 'ANSIDESC'
     resource_assignment: 'ANSIGMNT'
     resource_group: 'ANSIRGRP'
-    related_scope: 'IYCWEMW1'
-    region_one: 'IYCWEML1'
-    region_two: 'IYCWEMM1'
+    related_scope: '{{ cmci_scope_http }}'
+    region_one: '{{ cmci_scope_alternate_1 }}'
+    region_two: '{{ cmci_scope_alternate_2 }}'
     target_scope: 'ANSITARG'
     def_ver: '1'
 
@@ -28,7 +28,7 @@
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
       context: '{{ cmci_context }}'
-      scope: '{{ cmci_scope }}'
+      scope: '{{ cmci_scope_https }}'
       insecure: true
 
     ibm.ibm_zos_cics.cmci_update:
@@ -37,7 +37,7 @@
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
       context: '{{ cmci_context }}'
-      scope: '{{ cmci_scope }}'
+      scope: '{{ cmci_scope_https }}'
       insecure: true
 
 
@@ -47,7 +47,7 @@
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
       context: '{{ cmci_context }}'
-      scope: '{{ cmci_scope }}'
+      scope: '{{ cmci_scope_https }}'
       insecure: true
 
 
@@ -57,7 +57,7 @@
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
       context: '{{ cmci_context }}'
-      scope: '{{ cmci_scope }}'
+      scope: '{{ cmci_scope_https }}'
       insecure: true
 
 
@@ -67,7 +67,7 @@
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
       context: '{{ cmci_context }}'
-      scope: '{{ cmci_scope }}'
+      scope: '{{ cmci_scope_https }}'
       insecure: true
 
 

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_bas_install.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_bas_install.yml
@@ -15,8 +15,8 @@
     resource_assignment: 'ANSIGMNT'
     resource_group: 'ANSIRGRP'
     related_scope: '{{ cmci_scope_http }}'
-    region_one: '{{ cmci_scope_alternate_1 }}'
-    region_two: '{{ cmci_scope_alternate_2 }}'
+    region_one: '{{ cmci_scope_region_1 }}'
+    region_two: '{{ cmci_scope_region_2 }}'
     target_scope: 'ANSITARG'
     def_ver: '1'
 

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_bas_install_error.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_bas_install_error.yml
@@ -9,7 +9,7 @@
   collections:
    - ibm.ibm_zos_cics
   hosts: 'localhost'
-  gather_facts: 'false'
+  gather_facts: false
   vars:
     res_def: 'ANSIFIL*'
     file1: 'ANSIFIL1'
@@ -19,8 +19,8 @@
     resource_assignment_type_target: 'CICSRemoteFile'
     resource_assignment_type_related: 'CICSLocalFile'
     resource_group: 'ANSIRGRP'
-    related_scope: 'IYCWEMW1'
-    target_scope: 'IYCWEML1'
+    related_scope: '{{ cmci_scope_http }}'
+    target_scope: '{{ cmci_scope_alternate_1 }}'
     def_ver: '1'
 
 
@@ -31,7 +31,7 @@
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
       context: '{{ cmci_context }}'
-      scope: '{{ cmci_scope }}'
+      scope: '{{ cmci_scope_https }}'
       insecure: true
 
     ibm.ibm_zos_cics.cmci_update:
@@ -40,7 +40,7 @@
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
       context: '{{ cmci_context }}'
-      scope: '{{ cmci_scope }}'
+      scope: '{{ cmci_scope_https }}'
       insecure: true
 
 
@@ -50,7 +50,7 @@
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
       context: '{{ cmci_context }}'
-      scope: '{{ cmci_scope }}'
+      scope: '{{ cmci_scope_https }}'
       insecure: true
 
 
@@ -60,7 +60,7 @@
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
       context: '{{ cmci_context }}'
-      scope: '{{ cmci_scope }}'
+      scope: '{{ cmci_scope_https }}'
       insecure: true
 
 
@@ -70,7 +70,7 @@
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
       context: '{{ cmci_context }}'
-      scope: '{{ cmci_scope }}'
+      scope: '{{ cmci_scope_https }}'
       insecure: true
 
 

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_bas_install_error.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_bas_install_error.yml
@@ -20,7 +20,7 @@
     resource_assignment_type_related: 'CICSLocalFile'
     resource_group: 'ANSIRGRP'
     related_scope: '{{ cmci_scope_http }}'
-    target_scope: '{{ cmci_scope_alternate_1 }}'
+    target_scope: '{{ cmci_scope_region_1 }}'
     def_ver: '1'
 
 

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_bas_link.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_bas_link.yml
@@ -7,12 +7,12 @@
   collections:
    - ibm.ibm_zos_cics
   hosts: 'localhost'
-  gather_facts: 'false'
+  gather_facts: false
   vars:
     program: 'ANSIPROG'
     resource_description: 'ANSIBAS'
     resource_group: 'ANSIGRP'
-    resource_scope: 'IYCWEMM1'
+    resource_scope: '{{ cmci_scope_alternate_2 }}'
     def_ver: '1'
 
 
@@ -23,7 +23,7 @@
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
       context: '{{ cmci_context }}'
-      scope: '{{ cmci_scope }}'
+      scope: '{{ cmci_scope_https }}'
       insecure: true
 
     ibm.ibm_zos_cics.cmci_update:
@@ -32,7 +32,7 @@
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
       context: '{{ cmci_context }}'
-      scope: '{{ cmci_scope }}'
+      scope: '{{ cmci_scope_https }}'
       insecure: true
 
 
@@ -42,7 +42,7 @@
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
       context: '{{ cmci_context }}'
-      scope: '{{ cmci_scope }}'
+      scope: '{{ cmci_scope_https }}'
       insecure: true
 
 
@@ -52,7 +52,7 @@
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
       context: '{{ cmci_context }}'
-      scope: '{{ cmci_scope }}'
+      scope: '{{ cmci_scope_https }}'
       insecure: true
 
 
@@ -62,7 +62,7 @@
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
       context: '{{ cmci_context }}'
-      scope: '{{ cmci_scope }}'
+      scope: '{{ cmci_scope_https }}'
       insecure: true
 
 

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_bas_link.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_bas_link.yml
@@ -12,7 +12,7 @@
     program: 'ANSIPROG'
     resource_description: 'ANSIBAS'
     resource_group: 'ANSIGRP'
-    resource_scope: '{{ cmci_scope_alternate_2 }}'
+    resource_scope: '{{ cmci_scope_region_2 }}'
     def_ver: '1'
 
 

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_create_pipeline_failure.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_create_pipeline_failure.yml
@@ -5,7 +5,7 @@
   collections:
    - ibm.ibm_zos_cics
   hosts: 'localhost'
-  gather_facts: 'false'
+  gather_facts: false
 
   tasks:
     - name: test create pipeline failure
@@ -16,7 +16,7 @@
         cmci_password: '{{ cmci_password }}'
         insecure: true
         context: '{{ cmci_context }}'
-        scope: '{{ cmci_scope }}'
+        scope: '{{ cmci_scope_https }}'
         type: 'CICSDefinitionPipeline'
         create_parameters:
           - name: 'CSD'

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_incorrect_context.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_incorrect_context.yml
@@ -5,7 +5,7 @@
   collections:
    - ibm.ibm_zos_cics
   hosts: 'localhost'
-  gather_facts: 'false'
+  gather_facts: false
 
   tasks:
     - name: test invalid context
@@ -16,7 +16,7 @@
         cmci_password: '{{ cmci_password }}'
         insecure: true
         context: 'invalid'
-        scope: '{{ cmci_scope }}'
+        scope: '{{ cmci_scope_https }}'
         type: 'cicsprogram'
       failed_when: false
       register: result

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_incorrect_host.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_incorrect_host.yml
@@ -23,7 +23,7 @@
         cmci_password: '{{ cmci_password }}'
         insecure: true
         context: '{{ cmci_context }}'
-        scope: '{{ cmci_scope }}'
+        scope: '{{ cmci_scope_https }}'
         type: 'cicsprogram'
       failed_when: false
       register: result

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_incorrect_port.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_incorrect_port.yml
@@ -5,7 +5,7 @@
   collections:
    - ibm.ibm_zos_cics
   hosts: 'localhost'
-  gather_facts: 'false'
+  gather_facts: false
 
   tasks:
     - name: test incorrect port
@@ -15,7 +15,7 @@
         cmci_user: '{{ cmci_user }}'
         cmci_password: '{{ cmci_password }}'
         context: '{{ cmci_context }}'
-        scope: '{{ cmci_scope }}'
+        scope: '{{ cmci_scope_https }}'
         type: 'cicsprogram'
       failed_when: false
       register: result

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_incorrect_scheme.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_incorrect_scheme.yml
@@ -55,7 +55,7 @@
         cmci_password: '{{ cmci_password }}'
 
         context: '{{ cmci_context }}'
-        scope: '{{ cmci_scope_alternate_1 }}'
+        scope: '{{ cmci_scope_region_1 }}'
         type: 'cicsprogram'
         scheme: 'https'
         insecure: true

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_incorrect_scheme.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_incorrect_scheme.yml
@@ -5,9 +5,8 @@
   collections:
    - ibm.ibm_zos_cics
   hosts: 'localhost'
-  gather_facts: 'true'
+  gather_facts: true
   vars:
-    http_scope: IYCWEMW1
     python_2_message: >-
       Error performing CMCI request{{ ':' }} ('Connection aborted.',
       BadStatusLine('No status line received - the server has closed the
@@ -26,7 +25,7 @@
         cmci_password: '{{ cmci_password }}'
 
         context: '{{ cmci_context }}'
-        scope: '{{ cmci_scope }}'
+        scope: '{{ cmci_scope_https }}'
         type: 'cicsprogram'
         scheme: 'http'
         insecure: true
@@ -56,7 +55,7 @@
         cmci_password: '{{ cmci_password }}'
 
         context: '{{ cmci_context }}'
-        scope: '{{ http_scope }}'
+        scope: '{{ cmci_scope_alternate_1 }}'
         type: 'cicsprogram'
         scheme: 'https'
         insecure: true

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_incorrect_scope.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_incorrect_scope.yml
@@ -5,7 +5,7 @@
   collections:
    - ibm.ibm_zos_cics
   hosts: 'localhost'
-  gather_facts: 'false'
+  gather_facts: false
 
   tasks:
     - name: test invalid scope

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_insecure_false.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_insecure_false.yml
@@ -5,7 +5,7 @@
   collections:
    - ibm.ibm_zos_cics
   hosts: 'localhost'
-  gather_facts: 'false'
+  gather_facts: false
 
   tasks:
     - name: test insecure false
@@ -15,7 +15,7 @@
         cmci_user: '{{ cmci_user }}'
         cmci_password: '{{ cmci_password }}'
         context: '{{ cmci_context }}'
-        scope: '{{ cmci_scope }}'
+        scope: '{{ cmci_scope_https }}'
         type: 'cicsprogram'
         insecure: false
         resources:

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_install_bundle_failure.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_install_bundle_failure.yml
@@ -5,7 +5,7 @@
   collections:
    - ibm.ibm_zos_cics
   hosts: 'localhost'
-  gather_facts: 'false'
+  gather_facts: false
   vars:
     csdgroup: 'ANSITEST'
     bunddef: 'ANSIBUND'
@@ -17,7 +17,7 @@
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
       context: '{{ cmci_context }}'
-      scope: '{{ cmci_scope }}'
+      scope: '{{ cmci_scope_https }}'
       insecure: true
 
     ibm.ibm_zos_cics.cmci_action:
@@ -26,7 +26,7 @@
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
       context: '{{ cmci_context }}'
-      scope: '{{ cmci_scope }}'
+      scope: '{{ cmci_scope_https }}'
       insecure: true
 
     ibm.ibm_zos_cics.cmci_create:
@@ -35,7 +35,7 @@
       cmci_user: '{{ cmci_user }}'
       cmci_password: '{{ cmci_password }}'
       context: '{{ cmci_context }}'
-      scope: '{{ cmci_scope }}'
+      scope: '{{ cmci_scope_https }}'
       insecure: true
 
 
@@ -112,7 +112,7 @@
           - result.feedback[1].action == 'CSDINSTALL'
           - result.feedback[1].eibfn == 'A20E'
           - result.feedback[1].eibfn_alt == 'CSD INSTALL'
-          - result.feedback[1].eyu_cicsname == cmci_scope
+          - result.feedback[1].eyu_cicsname == cmci_scope_https
           - result.feedback[1].resp == '16'
           - result.feedback[1].resp2 == '633' #'Installation of BUNDLE resource resource failed because the resource had no manifest'
           - result.feedback[1].resp_alt == 'INVREQ'

--- a/tests/integration/targets/cics_cmci/playbooks/cmci_invalid_credentials.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cmci_invalid_credentials.yml
@@ -5,7 +5,7 @@
   collections:
    - ibm.ibm_zos_cics
   hosts: 'localhost'
-  gather_facts: 'false'
+  gather_facts: false
 
   vars:
     fail_message: "CMCI request returned non-OK status{{':'}} Unauthorized"
@@ -19,7 +19,7 @@
         cmci_password: '{{ cmci_password }}'
         insecure: true
         context: '{{ cmci_context }}'
-        scope: '{{ cmci_scope }}'
+        scope: '{{ cmci_scope_https }}'
         type: 'cicsprogram'
       failed_when: false
       register: result

--- a/tests/integration/targets/cics_cmci_missing_requests_library/playbooks/cmci_missing_requests.yml
+++ b/tests/integration/targets/cics_cmci_missing_requests_library/playbooks/cmci_missing_requests.yml
@@ -5,7 +5,7 @@
   collections:
    - ibm.ibm_zos_cics
   hosts: 'localhost'
-  gather_facts: 'false'
+  gather_facts: false
 
   tasks:
     - name: test missing requests library
@@ -20,10 +20,6 @@
         type: 'cicsprogram'
       failed_when: false
       register: result
-
-    - name: debug
-      debug:
-        msg: '{{ result.msg }}'
 
     - name: assert
       assert:

--- a/tests/integration/targets/cics_cmci_missing_xmltodict_library/playbooks/cmci_missing_xmltodict.yml
+++ b/tests/integration/targets/cics_cmci_missing_xmltodict_library/playbooks/cmci_missing_xmltodict.yml
@@ -5,7 +5,7 @@
   collections:
    - ibm.ibm_zos_cics
   hosts: 'localhost'
-  gather_facts: 'false'
+  gather_facts: false
 
   tasks:
     - name: test missing xmltodict library
@@ -20,10 +20,6 @@
         type: 'cicsprogram'
       failed_when: false
       register: result
-
-    - name: debug
-      debug:
-        msg: '{{ result.msg }}'
 
     - name: assert
       assert:

--- a/tests/unit/helpers/cmci_helper.py
+++ b/tests/unit/helpers/cmci_helper.py
@@ -61,6 +61,15 @@ class CMCITestHelper:
             **kwargs
         )
 
+    def stub_nodata(self, method, resource_type, *args, **kwargs):
+        return self.stub_cmci(
+            method,
+            resource_type,
+            response_dict=create_nodata_response(),
+            *args,
+            **kwargs
+        )
+
     def stub_non_ok_records(self, method, resource_type, feedback, *args, **kwargs):
         return self.stub_cmci(
             method,
@@ -73,7 +82,7 @@ class CMCITestHelper:
     def stub_cmci(self, method, resource_type, scheme='https', host=HOST, port=PORT,
                   context=CONTEXT, scope=None, parameters='', response_dict=None,
                   headers=None, status_code=200, reason='OK',
-                  record_count=None, **kwargs):
+                  record_count=None, fail_on_nodata=True, **kwargs):
         if headers is None:
             headers = {'CONTENT-TYPE': 'application/xml'}
         url = '{0}://{1}:{2}/CICSSystemManagement/{3}/{4}/{5}{6}{7}'\
@@ -203,6 +212,17 @@ def create_records_response(resource_type, records):  # type: (str, List) -> Ord
                 resource_type.lower(),
                 [OrderedDict([('@' + key, value) for key, value in record.items()]) for record in records]
             )
+        ))
+    )
+
+def create_nodata_response(): # type: (str, List) -> OrderedDict
+    return create_cmci_response(
+        ('resultsummary', od(
+            ('@api_response1', '1027'),
+            ('@api_response2', '0'),
+            ('@api_response1_alt', 'NODATA'),
+            ('@api_response2_alt', ''),
+            ('@recordcount', '0')
         ))
     )
 


### PR DESCRIPTION
##### SUMMARY
Adds the `fail_on_nodata` attribute (True by default) to the cmci_get task that prevents the ansible task from failing if no data is returned from CMCI. 

Currently the CPSM response code received by ansible is 1027 when no records are present, which is considered an error by the cmci_get task. Setting the `fail_on_nodata` attribute to False prevents the ansible task from failing and returns the successful response, just with no records. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Fail_on_nodata cmci_get feature

##### ADDITIONAL INFORMATION

Setting the new attribute:

```yaml
tasks:
    - name: Check CSD Already Exists
      cmci_get:
        context: "{{ context }}"
        scope: "{{ scope }}"
        cmci_host: "{{ cmci_host }}"
        cmci_port: "{{ cmci_port | int }}"
        cmci_user: "{{ cmci_user | default(omit) }}"
        cmci_password: "{{ cmci_password | default(omit) }}"
        scheme: "{{ scheme }}"
        type: CICSCSDGroup
        resources:
          filter:
            name: "{{ csdgroup }}"
        record_count: 1
        fail_on_nodata: "false"
```

###### Previous Output

```
fatal: [localhost]: FAILED! => 
    {"changed": false, "connect_version": "0610", "cpsm_reason": "", "cpsm_reason_code": 0, "cpsm_response": "NODATA", "cpsm_response_code": 1027, "http_status": "OK", "http_status_code": 200, "msg": "CMCI request failed with response \"NODATA\" reason \"1027\"", "record_count": 0, "request": {"body": null, "method": "GET", "url": "..."}}
```

###### Updated Output with Added Feature

```
ok: [localhost] => {
    "{'changed': False, 'request': {'url': '...', 'method': 'GET', 'body': None}, 'http_status_code': 200, 'http_status': 'OK', 'connect_version': '0610', 'cpsm_response': 'NODATA', 'cpsm_response_code': 1027, 'cpsm_reason': '', 'cpsm_reason_code': 0, 'record_count': 0, 'failed': False}"
}
```

