### PR TITLE
adding module defaults functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ venv3
 tests/output
 ibm-ibm_zos_cics-*.tar.gz
 tests/integration/targets/cics_cmci/cmci-variables.yml
+tests/integration/inventory

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,8 @@
 # (c) Copyright IBM Corp. 2020,2021
 # Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)
 -r requirements.txt
-ansible==2.10.7
+ansible-core==2.13.7; python_version >= '3'
+ansible-core==2.11.12; python_version < '3'
 junit-xml==1.9  # To get JUnit xml report from ansible-test
 pytest_mock==1.12.1
 mock==3.0.5

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,6 +1,6 @@
 requires_ansible: '>=2.10.7'
 action_groups:
-  cmci:
+  cmci_group:
     - cmci_action
     - cmci_create
     - cmci_delete

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,1 +1,8 @@
 requires_ansible: '>=2.10.7'
+action_groups:
+  cmci:
+    - cmci_action
+    - cmci_create
+    - cmci_delete
+    - cmci_get
+    - cmci_update

--- a/tests/integration/targets/cics_cmci/playbooks/cics_cmci_module_defaults.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cics_cmci_module_defaults.yml
@@ -16,7 +16,7 @@
     error_msg: "{{ error_msg_27 if lookup('env', 'ANSIBLE_TEST_PYTHON_VERSION') == '2.7' else error_msg_38 }}"
 
   module_defaults:
-    group/ibm.ibm_zos_cics.cmci:
+    group/ibm.ibm_zos_cics.cmci_group:
       cmci_host: "{{ cmci_host }}"
       cmci_port: "{{ cmci_port }}"
       cmci_user: "{{ cmci_user }}"

--- a/tests/integration/targets/cics_cmci/playbooks/cics_cmci_module_defaults.yml
+++ b/tests/integration/targets/cics_cmci/playbooks/cics_cmci_module_defaults.yml
@@ -1,0 +1,457 @@
+# (c) Copyright IBM Corp. 2020,2021
+# Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)
+---
+- name: CMCI Group Module_Default Integration Tests
+  collections:
+    - ibm.ibm_zos_cics
+  hosts: localhost
+  gather_facts: false
+  vars:
+    csdgroup: HTTPTEST
+    program: HTTPTEST
+    program_2: HTTPTES2
+    program_filter: HTTPTES*
+    error_msg_27: "missing required arguments: cmci_host, cmci_port, context"
+    error_msg_38: CMCI request failed with response "NODATA" reason "1027"
+    error_msg: "{{ error_msg_27 if lookup('env', 'ANSIBLE_TEST_PYTHON_VERSION') == '2.7' else error_msg_38 }}"
+
+  module_defaults:
+    group/ibm.ibm_zos_cics.cmci:
+      cmci_host: "{{ cmci_host }}"
+      cmci_port: "{{ cmci_port }}"
+      cmci_user: "{{ cmci_user }}"
+      cmci_password: "{{ cmci_password }}"
+      context: "{{ cmci_context }}"
+      scope: "{{ cmci_scope_http }}"
+      insecure: true
+      scheme: http
+
+  tasks:
+    - name: HTTP Delete progdef
+      delegate_to: localhost
+      cmci_delete:
+        type: CICSDefinitionProgram
+        resources:
+          complex_filter:
+            and:
+              - attribute: NAME
+                value: "{{ program }}"
+              - attribute: CSDGROUP
+                value: "{{ csdgroup }}"
+          get_parameters:
+            - name: CSDGROUP
+              value: "{{ csdgroup }}"
+      register: result
+      failed_when: false
+
+    - name: Assert
+      ansible.builtin.assert:
+        that:
+          - result.changed == false
+          - result.failed_when_result == false
+          - result.msg == error_msg
+
+    - name: HTTP Create progdef
+      delegate_to: localhost
+      cmci_create:
+        type: CICSDefinitionProgram
+        attributes:
+          name: "{{ program }}"
+          csdgroup: "{{ csdgroup }}"
+        create_parameters:
+          - name: CSD
+      register: result
+      failed_when: false
+
+    - name: Assert 1 38
+      when: lookup('env', 'ANSIBLE_TEST_PYTHON_VERSION') == '3.8'
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.cpsm_response == 'OK'
+          - result.record_count == 1
+          - result.records[0].name == program
+
+    - name: Assert 1 27
+      when: lookup('env', 'ANSIBLE_TEST_PYTHON_VERSION') == '2.7'
+      ansible.builtin.assert:
+        that:
+          - result.changed == false
+          - result.failed_when_result == false
+          - result.msg == error_msg
+
+    - name: HTTP Update progdef
+      delegate_to: localhost
+      cmci_update:
+        type: CICSDefinitionProgram
+        attributes:
+          description: foo
+        resources:
+          filter:
+            NAME: "{{ program }}"
+          get_parameters:
+            - name: CSDGROUP
+              value: "{{ csdgroup }}"
+      register: result
+      failed_when: false
+
+    - name: Assert 2 38
+      when: lookup('env', 'ANSIBLE_TEST_PYTHON_VERSION') == '3.8'
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.cpsm_response == 'OK'
+          - result.record_count == 1
+          - result.records[0].description == 'foo'
+
+    - name: Assert 2 27
+      when: lookup('env', 'ANSIBLE_TEST_PYTHON_VERSION') == '2.7'
+      ansible.builtin.assert:
+        that:
+          - result.changed == false
+          - result.failed_when_result == false
+          - result.msg == error_msg
+
+    - name: HTTP Install program
+      delegate_to: localhost
+      cmci_action:
+        type: CICSDefinitionProgram
+        action_name: CSDINSTALL
+        resources:
+          filter:
+            NAME: "{{ program }}"
+          get_parameters:
+            - name: CSDGROUP
+              value: "{{ csdgroup }}"
+      register: result
+      failed_when: false
+
+    - name: Assert 3 38
+      when: lookup('env', 'ANSIBLE_TEST_PYTHON_VERSION') == '3.8'
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.cpsm_response == 'OK'
+          - result.record_count == 1
+
+    - name: Assert 3 27
+      when: lookup('env', 'ANSIBLE_TEST_PYTHON_VERSION') == '2.7'
+      ansible.builtin.assert:
+        that:
+          - result.changed == false
+          - result.failed_when_result == false
+          - result.msg == error_msg
+
+    - name: HTTP Check program was installed
+      delegate_to: localhost
+      cmci_get:
+        type: CICSProgram
+        resources:
+          filter:
+            PROGRAM: "{{ program }}"
+      retries: 3 # May take a while to install, so give it a chance!
+      until: result is not failed
+      register: result
+      failed_when: false
+
+    - name: Assert 4 38
+      when: lookup('env', 'ANSIBLE_TEST_PYTHON_VERSION') == '3.8'
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - result.cpsm_response == 'OK'
+          - result.record_count == 1
+          - result.records[0].program == program
+
+    - name: Assert 4 27
+      when: lookup('env', 'ANSIBLE_TEST_PYTHON_VERSION') == '2.7'
+      ansible.builtin.assert:
+        that:
+          - result.changed == false
+          - result.failed_when_result == false
+          - result.msg == error_msg
+
+    - name: HTTP Disable program
+      delegate_to: localhost
+      cmci_update:
+        type: CICSProgram
+        attributes:
+          status: disabled
+        resources:
+          filter:
+            PROGRAM: "{{ program }}"
+          complex_filter:
+            and:
+              - attribute: PROGRAM
+                operator: "="
+                value: "{{ program }}"
+              - or:
+                  - attribute: USECOUNT
+                    operator: "!="
+                    value: "0"
+                  - attribute: USECOUNT
+                    operator: LT
+                    value: "1"
+      register: result
+      failed_when: false
+
+    - name: Assert 5 38
+      when: lookup('env', 'ANSIBLE_TEST_PYTHON_VERSION') == '3.8'
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.cpsm_response == 'OK'
+          - result.record_count == 1
+          - result.records[0].program == program
+          - result.records[0].status == 'DISABLED'
+
+    - name: Assert 5 27
+      when: lookup('env', 'ANSIBLE_TEST_PYTHON_VERSION') == '2.7'
+      ansible.builtin.assert:
+        that:
+          - result.changed == false
+          - result.failed_when_result == false
+          - result.msg == error_msg
+
+    - name: HTTP Delete program
+      delegate_to: localhost
+      cmci_delete:
+        type: CICSProgram
+        resources:
+          filter:
+            PROGRAM: "{{ program }}"
+      register: result
+      failed_when: false
+
+    - name: Assert 6 38
+      when: lookup('env', 'ANSIBLE_TEST_PYTHON_VERSION') == '3.8'
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.cpsm_response == 'OK'
+          - result.record_count == 1
+          - result.success_count == 1
+
+    - name: Assert 6 27
+      when: lookup('env', 'ANSIBLE_TEST_PYTHON_VERSION') == '2.7'
+      ansible.builtin.assert:
+        that:
+          - result.changed == false
+          - result.failed_when_result == false
+          - result.msg == error_msg
+
+    - name: HTTP Create progdef 2
+      delegate_to: localhost
+      cmci_create:
+        type: CICSDefinitionProgram
+        attributes:
+          name: "{{ program_2 }}"
+          csdgroup: "{{ csdgroup }}"
+        create_parameters:
+          - name: CSD
+      register: result
+      failed_when: false
+
+    - name: Assert program_2 created 38
+      when: lookup('env', 'ANSIBLE_TEST_PYTHON_VERSION') == '3.8'
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.cpsm_response == 'OK'
+          - result.record_count == 1
+          - result.records[0].name == program_2
+
+    - name: Assert program_2 created 27
+      when: lookup('env', 'ANSIBLE_TEST_PYTHON_VERSION') == '2.7'
+      ansible.builtin.assert:
+        that:
+          - result.changed == false
+          - result.failed_when_result == false
+          - result.msg == error_msg
+
+    - name: HTTP Check All Records Returned
+      delegate_to: localhost
+      cmci_get:
+        type: CICSDefinitionProgram
+        resources:
+          filter:
+            name: "{{ program_filter }}"
+          get_parameters:
+            - name: CSDGROUP
+              value: "{{ csdgroup }}"
+      register: result
+      failed_when: false
+
+    - name: Assert record_count is 2 38
+      when: lookup('env', 'ANSIBLE_TEST_PYTHON_VERSION') == '3.8'
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - result.cpsm_response == 'OK'
+          - result.record_count == 2
+
+    - name: Assert record_count is 2 27
+      when: lookup('env', 'ANSIBLE_TEST_PYTHON_VERSION') == '2.7'
+      ansible.builtin.assert:
+        that:
+          - result.changed == false
+          - result.failed_when_result == false
+          - result.msg == error_msg
+
+    - name: HTTP Check record count attribute
+      delegate_to: localhost
+      cmci_get:
+        type: CICSDefinitionProgram
+        record_count: 1
+        resources:
+          filter:
+            name: "{{ program_filter }}"
+          get_parameters:
+            - name: CSDGROUP
+              value: "{{ csdgroup }}"
+      register: result
+      failed_when: false
+
+    - name: Assert record_count attribute 38
+      when: lookup('env', 'ANSIBLE_TEST_PYTHON_VERSION') == '3.8'
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - result.cpsm_response == 'OK'
+          - result.record_count == 2
+          - result.records|length == 1
+
+    - name: Assert record_count attribute 27
+      when: lookup('env', 'ANSIBLE_TEST_PYTHON_VERSION') == '2.7'
+      ansible.builtin.assert:
+        that:
+          - result.changed == false
+          - result.failed_when_result == false
+          - result.msg == error_msg
+
+    - name: HTTP Delete progdef
+      delegate_to: localhost
+      cmci_delete:
+        type: CICSDefinitionProgram
+        resources:
+          filter:
+            NAME: "{{ program }}"
+          get_parameters:
+            - name: CSDGROUP
+              value: "{{ csdgroup }}"
+      register: result
+      failed_when: false
+
+    - name: Assert 7 38
+      when: lookup('env', 'ANSIBLE_TEST_PYTHON_VERSION') == '3.8'
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.cpsm_response == 'OK'
+          - result.record_count == 1
+          - result.success_count == 1
+
+    - name: Assert 7 27
+      when: lookup('env', 'ANSIBLE_TEST_PYTHON_VERSION') == '2.7'
+      ansible.builtin.assert:
+        that:
+          - result.changed == false
+          - result.failed_when_result == false
+          - result.msg == error_msg
+
+    - name: HTTP Delete progdef2
+      delegate_to: localhost
+      cmci_delete:
+        type: CICSDefinitionProgram
+        resources:
+          filter:
+            NAME: "{{ program_2 }}"
+          get_parameters:
+            - name: CSDGROUP
+              value: "{{ csdgroup }}"
+      register: result
+      failed_when: false
+
+    - name: Assert program_2 deleted 38
+      when: lookup('env', 'ANSIBLE_TEST_PYTHON_VERSION') == '3.8'
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.cpsm_response == 'OK'
+          - result.record_count == 1
+          - result.success_count == 1
+
+    - name: Assert program_2 deleted 27
+      when: lookup('env', 'ANSIBLE_TEST_PYTHON_VERSION') == '2.7'
+      ansible.builtin.assert:
+        that:
+          - result.changed == false
+          - result.failed_when_result == false
+          - result.msg == error_msg
+
+    - name: HTTP fail_on_nodata default
+      delegate_to: localhost
+      cmci_get:
+        type: CICSDefinitionProgram
+        resources:
+          filter:
+            name: "{{ program_filter }}"
+          get_parameters:
+            - name: CSDGROUP
+              value: "{{ csdgroup }}"
+      register: result
+      failed_when: false
+
+    - name: Assert fail_on_nodata attribute default 38
+      when: lookup('env', 'ANSIBLE_TEST_PYTHON_VERSION') == '3.8'
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - result.failed == false
+          - result.cpsm_response == 'NODATA'
+          - result.cpsm_response_code == 1027
+          - result.record_count == 0
+          - result.msg is defined
+          - result.failed_when_result is defined
+
+    - name: Assert fail_on_nodata attribute default 27
+      when: lookup('env', 'ANSIBLE_TEST_PYTHON_VERSION') == '2.7'
+      ansible.builtin.assert:
+        that:
+          - result.changed == false
+          - result.failed_when_result == false
+          - result.msg == error_msg
+
+    - name: HTTP fail_on_nodata
+      delegate_to: localhost
+      cmci_get:
+        type: CICSDefinitionProgram
+        fail_on_nodata: false
+        resources:
+          filter:
+            name: "{{ program_filter }}"
+          get_parameters:
+            - name: CSDGROUP
+              value: "{{ csdgroup }}"
+      register: result
+      failed_when: false
+
+    - name: Assert fail_on_nodata attribute false 38
+      when: lookup('env', 'ANSIBLE_TEST_PYTHON_VERSION') == '3.8'
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - result.failed == false
+          - result.cpsm_response == 'NODATA'
+          - result.cpsm_response_code == 1027
+          - result.record_count == 0
+          - result.msg is not defined
+          - result.failed_when_result == false
+
+    - name: Assert fail_on_nodata attribute false 27
+      when: lookup('env', 'ANSIBLE_TEST_PYTHON_VERSION') == '2.7'
+      ansible.builtin.assert:
+        that:
+          - result.changed == false
+          - result.failed_when_result == false
+          - result.msg == error_msg

--- a/tests/integration/targets/cics_cmci/runme.sh
+++ b/tests/integration/targets/cics_cmci/runme.sh
@@ -16,3 +16,4 @@ ansible-playbook -e "@cmci-variables.yml" playbooks/cmci_incorrect_scheme.yml
 ansible-playbook -e "@cmci-variables.yml" playbooks/cmci_bas_link.yml
 ansible-playbook -e "@cmci-variables.yml" playbooks/cmci_bas_install.yml
 ansible-playbook -e "@cmci-variables.yml" playbooks/cmci_bas_install_error.yml
+ansible-playbook -e "@cmci-variables.yml" playbooks/cics_cmci_module_defaults.yml

--- a/tests/unit/helpers/cmci_helper.py
+++ b/tests/unit/helpers/cmci_helper.py
@@ -123,18 +123,14 @@ class CMCITestHelper:
         assert isinstance(self.expected, dict)
         assert isinstance(result, dict)
 
+        # when a list of items is expected but the order varies, this block intecepts the actual result and sorts
+        # the list, allowing the expected and actual output to be compared in the same order
         if self.expected_list:
-            # get list of items from a string in the result dict - comma separated text between 2 points in string
             actual_list = result.get(self.string_containing_list)[self.chars_before_list:-self.chars_after_list].split(", ")
-            # sort alphabetically
             actual_list.sort()
-            # get the text before the list in the string
             before_list = result.get(self.string_containing_list)[:self.chars_before_list]
-            # get the text after the list in the string
             after_list = result.get(self.string_containing_list)[-self.chars_after_list:]
-            # put the text before and after the list together with the newly ordered list
             concat = before_list + ", ".join(actual_list) + after_list
-            # update the result dict to use the string with the ordered list of items
             result.update({self.string_containing_list: concat})
 
         if self.expected != result:

--- a/tests/unit/helpers/cmci_helper.py
+++ b/tests/unit/helpers/cmci_helper.py
@@ -30,6 +30,7 @@ class CMCITestHelper:
     def __init__(self, requests_mock=None):
         self.requests_mock = requests_mock
         self.expected = {}
+        self.expected_list = False
 
     def stub_request(self, *args, **kwargs):
         self.requests_mock.request(complete_qs=True, *args, **kwargs)
@@ -102,6 +103,12 @@ class CMCITestHelper:
     def expect(self, expected):
         self.expected = expected
 
+    def expect_list(self, chars_before_list, chars_after_list, string_containing_list='msg'):
+        self.expected_list = True
+        self.chars_before_list = chars_before_list
+        self.chars_after_list = chars_after_list
+        self.string_containing_list = string_containing_list
+
     def run(self, module, config):
         # upper-case the resource name, so it definitely doesn't match the CMCI response, to ensure
         # we don't rely on them matching
@@ -115,6 +122,20 @@ class CMCITestHelper:
 
         assert isinstance(self.expected, dict)
         assert isinstance(result, dict)
+
+        if self.expected_list:
+            # get list of items from a string in the result dict - comma separated text between 2 points in string
+            actual_list = result.get(self.string_containing_list)[self.chars_before_list:-self.chars_after_list].split(", ")
+            # sort alphabetically
+            actual_list.sort()
+            # get the text before the list in the string
+            before_list = result.get(self.string_containing_list)[:self.chars_before_list]
+            # get the text after the list in the string
+            after_list = result.get(self.string_containing_list)[-self.chars_after_list:]
+            # put the text before and after the list together with the newly ordered list
+            concat = before_list + ", ".join(actual_list) + after_list
+            # update the result dict to use the string with the ordered list of items
+            result.update({self.string_containing_list: concat})
 
         if self.expected != result:
             standard_msg = '%s != %s' % (repr(self.expected), repr(result))

--- a/tests/unit/modules/test_cmci_filters.py
+++ b/tests/unit/modules/test_cmci_filters.py
@@ -640,6 +640,10 @@ def test_extra_attributes_root(cmci_module):
     if sys.version_info.major <= 2:
         extension = "pyc"
 
+    # Order that Ansible returns supported parameters is not consistent everytime
+    # expect_list ensures expected and actual output are compared after sorting the 
+    # list first. This means passing tests if all expected attributes are listed, but not caring about
+    # the order. 
     before_list = "Unsupported parameters for (basic.%s) module: resources.complex_filter.orange. Supported parameters include: " % extension
     sorted_list = ["cmci_cert", "cmci_host", "cmci_key", "cmci_password",
                                 "cmci_port", "cmci_user", "context", "fail_on_nodata", "insecure",

--- a/tests/unit/modules/test_cmci_filters.py
+++ b/tests/unit/modules/test_cmci_filters.py
@@ -544,7 +544,7 @@ def test_complex_filter_default_operator_root(cmci_module):
 def test_required_by_root(cmci_module):
     # type: (CMCITestHelper) -> None
     cmci_module.expect({
-        'msg': "missing parameter(s) required by 'operator': attribute",
+        'msg': "missing parameter(s) required by 'operator': attribute found in resources -> complex_filter",
         'failed': True
     })
 
@@ -640,10 +640,19 @@ def test_extra_attributes_root(cmci_module):
     if sys.version_info.major <= 2:
         extension = "pyc"
 
+    before_list = "Unsupported parameters for (basic.%s) module: resources.complex_filter.orange. Supported parameters include: " % extension
+    sorted_list = ["cmci_cert", "cmci_host", "cmci_key", "cmci_password",
+                                "cmci_port", "cmci_user", "context", "fail_on_nodata", "insecure",
+                                "record_count", "resources", "scheme", "scope", "timeout", "type"]
+    after_list = "."
+
+    cmci_module.expect_list(
+        chars_before_list=len(before_list),
+        chars_after_list=len(after_list),
+        string_containing_list='msg'
+    )
     cmci_module.expect({
-        'msg': "Unsupported parameters for (basic.%s) module: orange found in "
-               "resources -> complex_filter. Supported parameters include: and,"
-               " attribute, operator, or, value" % extension,
+        'msg': before_list + ", ".join(sorted_list) + after_list,
         'failed': True
     })
 
@@ -722,7 +731,7 @@ def test_extra_attributes_or(cmci_module):
 def test_and_string_invalid(cmci_module):
     # type: (CMCITestHelper) -> None
     cmci_module.expect({
-        'msg': "Elements value for option and found in 'resources -> "
+        'msg': "Elements value for option 'and' found in 'resources -> "
                "complex_filter' is of type <%s 'str'> and we were unable to "
                "convert to dict: dictionary requested, could not parse JSON or"
                " key=value" % expected_type,
@@ -746,7 +755,7 @@ def test_and_string_invalid(cmci_module):
 def test_and_list_of_strings_invalid(cmci_module):
     # type: (CMCITestHelper) -> None
     cmci_module.expect({
-        'msg': "Elements value for option and found in 'resources -> "
+        'msg': "Elements value for option 'and' found in 'resources -> "
                "complex_filter' is of type <%s 'str'> and we were unable to "
                "convert to dict: dictionary requested, could not parse JSON or "
                "key=value" % expected_type,

--- a/tests/unit/modules/test_cmci_get.py
+++ b/tests/unit/modules/test_cmci_get.py
@@ -102,7 +102,7 @@ def test_invalid_port_type(cmci_module):  # type: (CMCITestHelper) -> None
         expected_type = 'type'
 
     cmci_module.expect({
-        'msg': "argument cmci_port is of type <" + expected_type + " 'str'> and we were unable to "
+        'msg': "argument 'cmci_port' is of type <" + expected_type + " 'str'> and we were unable to "
                "convert to int: <" + expected_type + " 'str'> cannot be converted to an int",
         'failed': True
     })


### PR DESCRIPTION
##### SUMMARY
Fixes #118 - adds the option to use Ansible's module_defaults feature to specify connection and environment details for all cics_cmci tasks in one place. 

This functionality is available when using Ansible-core 2.12+, which requires Python 3.8+. When running an environment that meets both the Ansible and Python requirement, the details can be specified by including the following:

```yaml
module_defaults:
    group/ibm.ibm_zos_cics.cmci:
      cmci_host: "{{ cmci_host }}"
      cmci_port: "{{ cmci_port }}"
      cmci_user: "{{ cmci_user }}"
      cmci_password: "{{ cmci_password }}"
      context: "{{ context }}"
      scope: "{{ scope }}"
      scheme: http
```

Under the `module_defaults` heading, a group in specified, followed by the name of the collection. In this case, the group of tasks is called `cmci`, so that group name is used after the collection name. Then whatever shared information can be put here. 

In the event the Ansible-core version is not up to date enough for this functionality (can be an outdated Ansible-core package version, or a capped version from an older Python version), a message similar to the one below is returned to the user:

```json
{"changed": false, "msg": "missing required arguments: cmci_host, cmci_port, context"}
```

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
CICS Ansible Collection Module Defaults

Signed-off-by: Andrew Twydell <andrew.twydell@ibm.com>