### PR TITLE
fixup: allow Applid to include special chars

### DIFF
--- a/plugins/modules/region_jcl.py
+++ b/plugins/modules/region_jcl.py
@@ -300,7 +300,7 @@ class AnsibleRegionJCLModule(DataSet):
         defs[STEPLIB]["options"][DATA_SETS].update({"elements": "data_set_base"})
         defs[DFHRPL]["options"][TOP_DATA_SETS].update({"elements": "data_set_base"})
         defs[DFHRPL]["options"][DATA_SETS].update({"elements": "data_set_base"})
-        self.update_arg_def(defs[APPLID], "qualifier")
+        self.update_arg_def(defs[APPLID], "dd")
         if defs.get(JOB_PARAMETERS) and defs[JOB_PARAMETERS]["options"].get(JOB_NAME):
             # If they've provided a job_name we need to validate this too
             self.update_arg_def(defs[JOB_PARAMETERS]["options"][JOB_NAME], "qualifier")

--- a/tests/unit/modules/test_region_jcl.py
+++ b/tests/unit/modules/test_region_jcl.py
@@ -765,7 +765,24 @@ def test_validate_parameters_applid_too_long():
     with pytest.raises(AnsibleFailJson) as exec_info:
         module = setup_and_update_parms({"applid": applid})
         assert module.result["failed"]
-    assert exec_info.value.args[0]['msg'] == 'Invalid argument "{0}" for type "qualifier".'.format(applid)
+    assert exec_info.value.args[0]['msg'] == 'Invalid argument "{0}" for type "dd".'.format(applid)
+
+
+def test_validate_parameters_applid_with_special_chars():
+    prepare_for_exit()
+    applid = "APP$@#"
+    module = setup_and_update_parms({"applid": applid})
+    module._exit()
+    assert not module.result["failed"]
+
+
+def test_validate_parameters_applid_with_unacceptable_special_chars():
+    prepare_for_fail()
+    applid = "AP$@#!£%"
+    with pytest.raises(AnsibleFailJson) as exec_info:
+        module = setup_and_update_parms({"applid": applid})
+        assert module.result["failed"]
+    assert exec_info.value.args[0]['msg'] == 'Invalid argument "{0}" for type "dd".'.format(applid)
 
 
 def test_validate_parameters_steplib_library_too_long():


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Allows a user to specify an Applid that includes special chars $@#
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
region_jcl

