### PR TITLE
Make requirements versions a lower bound

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 docs/build/
 .idea
 .vscode/settings.json
+.ansible
 __pycache__
 venv*
 .venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # (c) Copyright IBM Corp. 2020,2023
 # Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)
-requests==2.32.3
-xmltodict==0.12.0
-urllib3==1.26.19
+requests >= 2.32.3, < 3.0
+xmltodict >= 0.12.0, < 1.0
+urllib3 >= 1.26.19, < 2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@
 # Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)
 requests==2.32.3
 xmltodict==0.12.0
-urllib3==1.26.18
+urllib3==1.26.19


### PR DESCRIPTION
##### SUMMARY
Slacken the requirement specifiers in our requirements.yaml.  This establishes the versions in the requirements file as lower-bounds, and means we should be able to co-exist with other collections that have dependencies on the same libraries more easily.  This is important when building an execution environment, and actually resolves an incompatibility when building an execution environment which includes all the IBM Z collections.
