### PR TITLE
CVE 2024 37891

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@
 # Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)
 requests==2.32.3
 xmltodict==0.12.0
-urllib3==1.26.18
+urllib3==1.26.19


### PR DESCRIPTION
Increase the version of `urllib3` we require transitively via `requests`.  This is to address [CVE-2024-37891](https://access.redhat.com/security/cve/cve-2024-37891)